### PR TITLE
Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustwlc 0.2.1 (git+https://github.com/Immington-Industries/rust-wlc.git)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,14 +2,33 @@
 name = "way-cooler"
 version = "0.1.0"
 dependencies = [
+ "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustwlc 0.2.1 (git+https://github.com/Immington-Industries/rust-wlc.git)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "env_logger"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "lazy_static"
@@ -22,6 +41,41 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "log"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mempool"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mempool 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustwlc"
 version = "0.2.1"
 source = "git+https://github.com/Immington-Industries/rust-wlc.git#e58c0768a037639461a116e65f6d8313f0247ae4"
@@ -29,4 +83,9 @@ dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticp
 [dependencies]
 rustwlc = { git = "https://github.com/Immington-Industries/rust-wlc.git" }
 lazy_static = "*"
+log = "*"
+env_logger = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ rustwlc = { git = "https://github.com/Immington-Industries/rust-wlc.git" }
 lazy_static = "*"
 log = "*"
 env_logger = "*"
+libc = "*"

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -16,21 +16,21 @@ const EVENT_PASS_THROUGH: bool = false;
 // wlc callbacks
 
 pub extern fn output_created(output: WlcOutput) -> bool {
-    println!("output_created: {:?}: {}", output, output.get_name());
+    trace!("output_created: {:?}: {}", output, output.get_name());
     return true;
 }
 
 pub extern fn output_destroyed(output: WlcOutput) {
-    println!("output_destroyed: {:?}", output);
+    trace!("output_destroyed: {:?}", output);
 }
 
 pub extern fn output_focus(output: WlcOutput, focused: bool) {
-    println!("output_focus: {:?} focus={}", output, focused);
+    trace!("output_focus: {:?} focus={}", output, focused);
 }
 
 pub extern fn output_resolution(output: WlcOutput,
                             old_size_ptr: &Size, new_size_ptr: &Size) {
-    println!("output_resolution: {:?} from  {:?} to {:?}",
+    trace!("output_resolution: {:?} from  {:?} to {:?}",
              output, *old_size_ptr, *new_size_ptr);
 }
 /*
@@ -43,7 +43,7 @@ pub extern fn output_render_post(output: WlcOutput) {
 }
 */
 pub extern fn view_created(view: WlcView) -> bool {
-    println!("view_created: {:?}: \"{}\"", view, view.get_title());
+    trace!("view_created: {:?}: \"{}\"", view, view.get_title());
     let output = view.get_output();
     view.set_mask(output.get_mask());
     view.bring_to_front();
@@ -52,26 +52,26 @@ pub extern fn view_created(view: WlcView) -> bool {
 }
 
 pub extern fn view_destroyed(view: WlcView) {
-    println!("view_destroyed: {:?}", view);
+    trace!("view_destroyed: {:?}", view);
 }
 
 pub extern fn view_focus(current: WlcView, focused: bool) {
-    println!("view_focus: {:?} {}", current, focused);
+    trace!("view_focus: {:?} {}", current, focused);
     current.set_state(VIEW_ACTIVATED, focused);
 }
 
 pub extern fn view_move_to_output(current: WlcView,
                                   o1: WlcOutput, o2: WlcOutput) {
-    println!("view_move_to_output: {:?}, {:?}, {:?}", current, o1, o2);
+    trace!("view_move_to_output: {:?}, {:?}, {:?}", current, o1, o2);
 }
 
 pub extern fn view_request_geometry(view: WlcView, geometry: &Geometry) {
-    println!("view_request_geometry: {:?} wants {:?}", view, geometry);
+    trace!("view_request_geometry: {:?} wants {:?}", view, geometry);
     view.set_geometry(EDGE_NONE, geometry);
 }
 
 pub extern fn view_request_state(view: WlcView, state: ViewState, handled: bool) {
-    println!("view_request_state: {}, {:?}, handled: {}",
+    trace!("view_request_state: {}, {:?}, handled: {}",
     view.get_title(), state, handled);
     view.set_state(state, handled);
 }
@@ -79,18 +79,18 @@ pub extern fn view_request_state(view: WlcView, state: ViewState, handled: bool)
 pub extern fn view_request_move(view: WlcView, dest: &Point) {
     // Called by views when they have a dang resize mouse thing, we should only
     // let it happen in view floating mode
-    println!("view_request_move: to {}, start interactive mode.", *dest);
+    trace!("view_request_move: to {}, start interactive mode.", *dest);
 }
 
 pub extern fn view_request_resize(view: WlcView,
                               edge: ResizeEdge, location: &Point) {
-    println!("view_request_resize: edge {:?}, to {}, start interactive mode.",
+    trace!("view_request_resize: edge {:?}, to {}, start interactive mode.",
              edge, location);
 }
 
 pub extern fn keyboard_key(_view: WlcView, _time: u32, mods: &KeyboardModifiers,
                        key: u32, state: KeyState) -> bool {
-    println!("[key] pressed, mods {:?}, key {:?}, state {:?}",
+    trace!("[key] pressed, mods {:?}, key {:?}, state {:?}",
              &*mods, key, state);
 
     if state == KeyState::Pressed {
@@ -98,19 +98,19 @@ pub extern fn keyboard_key(_view: WlcView, _time: u32, mods: &KeyboardModifiers,
         // let mut keys = keyboard::get_current_keys().into_iter()
         //      .map(|&k| Keysym::from(k)).collect();
         let sym = keyboard::get_keysym_for_key(key, &KeyMod::empty());
-        println!("[key] Found sym named {}", sym.get_name().unwrap());
+        info!("[key] Found sym named {}", sym.get_name().unwrap());
         let mut keys = vec![sym];
 
         let press = KeyPress::new(mods.mods, keys);
-        println!("[key] Created Keypress {:?}", press);
+        info!("[key] Created Keypress {:?}", press);
 
         if let Some(action) = keys::get(&press) {
-            println!("[key] Found a key!");
+            info!("[key] Found a key!");
             action();
             return EVENT_HANDLED;
         }
         else {
-            println!("[key] No keypresses found.");
+            info!("[key] No keypresses found.");
         }
     }
 
@@ -120,7 +120,7 @@ pub extern fn keyboard_key(_view: WlcView, _time: u32, mods: &KeyboardModifiers,
 pub extern fn pointer_button(view: WlcView, button: u32,
                          mods_ptr: &KeyboardModifiers, key: u32,
                          state: ButtonState, point_ptr: &Point) -> bool {
-    println!("pointer_button: pressed {} at {}", key, *point_ptr);
+    trace!("pointer_button: pressed {} at {}", key, *point_ptr);
     if state == ButtonState::Pressed && !view.is_root() {
         view.focus();
     }
@@ -130,7 +130,7 @@ pub extern fn pointer_button(view: WlcView, button: u32,
 pub extern fn pointer_scroll(_view: WlcView, button: u32,
                          _mods_ptr: &KeyboardModifiers, axis: ScrollAxis,
                          heights: [u64; 2]) -> bool {
-    println!("pointer_scroll: press {}, {:?} to {:?}", button, axis, heights);
+    trace!("pointer_scroll: press {}, {:?} to {:?}", button, axis, heights);
     false
 }
 
@@ -147,5 +147,5 @@ pub extern fn touch(view: WlcView, time: u32, mods_ptr: &KeyboardModifiers,
 */
 
 pub extern fn compositor_ready() {
-    println!("Preparing compositor!");
+    info!("Preparing compositor!");
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -10,21 +10,21 @@ lazy_static! {
     static ref BINDINGS: RwLock<HashMap<KeyPress, KeyEvent>> = {
         let mut map = HashMap::<KeyPress, KeyEvent>::new();
         let press_s = KeyPress::from_key_names(vec!["Mod4"], vec!["s"]).unwrap();
-        println!("[bindings] Press_s: {:?}", press_s);
+        trace!("[bindings] Press_s: {:?}", press_s);
         map.insert(press_s, Arc::new(Box::new(key_s)));
         let press_f4 = KeyPress::from_key_names(vec!["Alt"], vec!["F4"]).unwrap();
-        println!("[bindings] press_f4: {:?}", press_f4);
+        trace!("[bindings] press_f4: {:?}", press_f4);
         map.insert(press_f4, Arc::new(Box::new(key_f4)));
         RwLock::new(map)
     };
 }
 
 fn key_s() {
-    println!("S keypress!");
+    info!("[Key handler] S keypress!");
 }
 
 fn key_f4() {
-    println!("F4 keypress!");
+    info!("[Key handler] F4 keypress!");
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
 //! Main module in way-cooler
 
 extern crate rustwlc;
-
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
 
 use rustwlc::interface::WlcInterface;
 
@@ -36,8 +38,10 @@ fn main() {
         //.input_created(input_created)
         //.input_destroyed(input_destroyed);
 
-    rustwlc::log_set_default_handler();
-
     let run_wlc = rustwlc::init(interface).expect("Unable to initialize wlc!");
+
+    env_logger::init().unwrap();
+    info!("Started logger");
+
     run_wlc();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,24 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
+extern crate libc;
 
 use rustwlc::interface::WlcInterface;
+use rustwlc::types::LogType;
 
 mod registry;
 mod keys;
 mod callbacks;
+
+extern "C" fn log_handler(level: LogType, message_ptr: *const libc::c_char) {
+    let message = unsafe { rustwlc::pointer_to_string(message_ptr) };
+    match level {
+        LogType::Info => info!("[wlc] {}", message),
+        LogType::Warn => warn!("[wlc] {}", message),
+        LogType::Error => error!("[wlc] {}", message),
+        LogType::Wayland => info!("[wlc:wayland] {}", message)
+    }
+}
 
 fn main() {
     let interface: WlcInterface = WlcInterface::new()
@@ -38,9 +50,12 @@ fn main() {
         //.input_created(input_created)
         //.input_destroyed(input_destroyed);
 
+    env_logger::init().unwrap();
+    info!("Logger initialized, setting wlc handler.");
+    rustwlc::log_set_handler(log_handler);
+
     let run_wlc = rustwlc::init(interface).expect("Unable to initialize wlc!");
 
-    env_logger::init().unwrap();
     info!("Started logger");
 
     run_wlc();

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -42,6 +42,7 @@ pub fn write_lock<'a>()
 
 /// Gets a value from the regsitry.
 pub fn get(name: &RegKey) -> Option<RegVal> {
+    trace!("get({})...", name);
     let mut val: Option<RegistryValue>;
     {
         let reg = REGISTRY.read().unwrap();


### PR DESCRIPTION
- Add dependencies to `log`, `env-logger`, and `libc` (for the `*const c_char` in the log handler)
- Initialize an `env-logger` in main
- Handle wlc's log by calling `log!` with the appropriate level
- Convert debug printing in the callbacks to a `trace!` log
- Add `info!` logs to the key press dummy handlers
- Add `trace!` to `registry::get`