### PR TITLE
Update first-features to rustwlc 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ dependencies = [
  "lazy_static 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustwlc 0.2.1 (git+https://github.com/Immington-Industries/rust-wlc.git)",
+ "rustwlc 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -108,8 +108,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustwlc"
-version = "0.2.1"
-source = "git+https://github.com/Immington-Industries/rust-wlc.git#e58c0768a037639461a116e65f6d8313f0247ae4"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticplace@gmail.com>"]
 
 [dependencies]
-rustwlc = { git = "https://github.com/Immington-Industries/rust-wlc.git" }
+rustwlc = "^0.3"
 lazy_static = "*"
 log = "*"
 env_logger = "*"

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -138,7 +138,7 @@ pub extern fn pointer_button(view: WlcView, _time: u32,
 
 pub extern fn pointer_scroll(_view: WlcView, button: u32,
                          _mods_ptr: &KeyboardModifiers, axis: ScrollAxis,
-                         heights: [u64; 2]) -> bool {
+                         heights: [f64; 2]) -> bool {
     trace!("pointer_scroll: press {}, {:?} to {:?}", button, axis, heights);
     false
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate log;
 extern crate env_logger;
 extern crate libc;
 
+use rustwlc::callback;
 use rustwlc::interface::WlcInterface;
 use rustwlc::types::LogType;
 
@@ -38,27 +39,26 @@ fn log_format(record: &log::LogRecord) -> String {
 }
 
 fn main() {
-    let interface: WlcInterface = WlcInterface::new()
-        .output_created(callbacks::output_created)
-        .output_destroyed(callbacks::output_destroyed)
-        .output_focus(callbacks::output_focus)
-        .output_resolution(callbacks::output_resolution)
+    callback::output_created(callbacks::output_created);
+    callback::output_destroyed(callbacks::output_destroyed);
+    callback::output_focus(callbacks::output_focus);
+    callback::output_resolution(callbacks::output_resolution);
         //.output_render_pre(callbacks::output_render_pre)
         //.output_render_post(callbacks::output_render_post)
-        .view_created(callbacks::view_created)
-        .view_destroyed(callbacks::view_destroyed)
-        .view_focus(callbacks::view_focus)
-        .view_move_to_output(callbacks::view_move_to_output)
-        .view_request_geometry(callbacks::view_request_geometry)
-        .view_request_state(callbacks::view_request_state)
-        .view_request_move(callbacks::view_request_move)
-        .view_request_resize(callbacks::view_request_resize)
-        .keyboard_key(callbacks::keyboard_key)
-        .pointer_button(callbacks::pointer_button)
-        .pointer_scroll(callbacks::pointer_scroll)
-        .pointer_motion(callbacks::pointer_motion)
+    callback::view_created(callbacks::view_created);
+    callback::view_destroyed(callbacks::view_destroyed);
+    callback::view_focus(callbacks::view_focus);
+    callback::view_move_to_output(callbacks::view_move_to_output);
+    callback::view_request_geometry(callbacks::view_request_geometry);
+    callback::view_request_state(callbacks::view_request_state);
+    callback::view_request_move(callbacks::view_request_move);
+    callback::view_request_resize(callbacks::view_request_resize);
+    callback::keyboard_key(callbacks::keyboard_key);
+    callback::pointer_button(callbacks::pointer_button);
+    callback::pointer_scroll(callbacks::pointer_scroll);
+    callback::pointer_motion(callbacks::pointer_motion);
         //.touch_touch(callbacks::touch)
-        .compositor_ready(callbacks::compositor_ready);
+    callback::compositor_ready(callbacks::compositor_ready);
         //.input_created(input_created)
         //.input_destroyed(input_destroyed);
 
@@ -72,7 +72,7 @@ fn main() {
     info!("Logger initialized, setting wlc handler.");
     rustwlc::log_set_handler(log_handler);
 
-    let run_wlc = rustwlc::init(interface).expect("Unable to initialize wlc!");
+    let run_wlc = rustwlc::init2().expect("Unable to initialize wlc!");
 
     info!("Started logger");
 


### PR DESCRIPTION
* Update `Cargo.*`
* Change `WlcInterface` builder to `callback` functions
* Update `pointer_scroll` callback to floats
* Use `rustlwc::init2()`