### PR TITLE
Registry properties

### DIFF
--- a/src/lua/funcs/lua_registry.rs
+++ b/src/lua/funcs/lua_registry.rs
@@ -1,6 +1,7 @@
 //! Metamethods for accesssing the registry values!
 
 use std::ops::Deref;
+use std::sync::Arc;
 
 use hlua::any::AnyLuaValue;
 use hlua::any::AnyLuaValue::LuaString;
@@ -11,26 +12,26 @@ use convert::ToTable;
 use convert::json::lua_to_json;
 
 pub fn index(_table: AnyLuaValue, lua_key: AnyLuaValue) -> AnyLuaValue {
-    /*if let LuaString(key) = lua_key {
+    if let LuaString(key) = lua_key {
         if let Ok((access, json_arc)) = registry::get_json(&key) {
             if access.contains(registry::LUA_READ) {
                 return json_arc.deref().clone().to_table();
             }
         }
-    }*/
+    }
     AnyLuaValue::LuaNil
 }
 
 // Prevent lua from changing the registry?
 pub fn new_index(_table: AnyLuaValue, lua_key: AnyLuaValue, val: AnyLuaValue)
                  -> Result<(), &'static str> {
-    /*if let LuaString(key) = lua_key {
+    if let LuaString(key) = lua_key {
         let json = try!(lua_to_json(val).map_err(
             |_| "Unable to convert value to JSON!"));
         let mut reg = registry::write_lock();
         let flags: AccessFlags;
-        if let Some(reg_val) = reg.get(&key) {
-            if let Some((access, _old_arc)) = reg_val.get_data() {
+        if let Some(reg_field) = reg.get(&key) {
+            if let Some((access, _old_arc)) = reg_field.clone().as_object() {
                 if !access.contains(LUA_WRITE) {
                     return Err("Unable to modify that key!");
                 }
@@ -43,11 +44,11 @@ pub fn new_index(_table: AnyLuaValue, lua_key: AnyLuaValue, val: AnyLuaValue)
         else {
             return Err("Cannot create a new key! Use config.set instead.");
         }
-        let new_val = RegistryValue::new_json(flags, json);
+        let new_val = RegistryField::Object {flags: flags, data: Arc::new(json) };
         reg.insert(key, new_val);
         return Err("That value does not yet exist!");
         // Putting an else here would mean allowing Lua code to create new keys
-    }*/
+    }
     return Err("Invalid key!");
 }
 

--- a/src/lua/funcs/lua_registry.rs
+++ b/src/lua/funcs/lua_registry.rs
@@ -6,25 +6,25 @@ use hlua::any::AnyLuaValue;
 use hlua::any::AnyLuaValue::LuaString;
 
 use registry;
-use registry::{RegistryValue, AccessFlags, LUA_WRITE};
+use registry::{RegistryField, AccessFlags, LUA_WRITE};
 use convert::ToTable;
 use convert::json::lua_to_json;
 
 pub fn index(_table: AnyLuaValue, lua_key: AnyLuaValue) -> AnyLuaValue {
-    if let LuaString(key) = lua_key {
+    /*if let LuaString(key) = lua_key {
         if let Ok((access, json_arc)) = registry::get_json(&key) {
             if access.contains(registry::LUA_READ) {
                 return json_arc.deref().clone().to_table();
             }
         }
-    }
+    }*/
     AnyLuaValue::LuaNil
 }
 
 // Prevent lua from changing the registry?
 pub fn new_index(_table: AnyLuaValue, lua_key: AnyLuaValue, val: AnyLuaValue)
                  -> Result<(), &'static str> {
-    if let LuaString(key) = lua_key {
+    /*if let LuaString(key) = lua_key {
         let json = try!(lua_to_json(val).map_err(
             |_| "Unable to convert value to JSON!"));
         let mut reg = registry::write_lock();
@@ -47,7 +47,7 @@ pub fn new_index(_table: AnyLuaValue, lua_key: AnyLuaValue, val: AnyLuaValue)
         reg.insert(key, new_val);
         return Err("That value does not yet exist!");
         // Putting an else here would mean allowing Lua code to create new keys
-    }
+    }*/
     return Err("Invalid key!");
 }
 

--- a/src/lua/funcs/lua_registry.rs
+++ b/src/lua/funcs/lua_registry.rs
@@ -7,14 +7,14 @@ use hlua::any::AnyLuaValue;
 use hlua::any::AnyLuaValue::LuaString;
 
 use registry;
-use registry::{RegistryField, AccessFlags, LUA_WRITE};
+use registry::{RegistryField, AccessFlags};
 use convert::ToTable;
 use convert::json::lua_to_json;
 
 pub fn index(_table: AnyLuaValue, lua_key: AnyLuaValue) -> AnyLuaValue {
     if let LuaString(key) = lua_key {
         if let Ok((access, json_arc)) = registry::get_json(&key) {
-            if access.contains(registry::LUA_READ) {
+            if access.contains(AccessFlags::READ()) {
                 return json_arc.deref().clone().to_table();
             }
         }
@@ -32,7 +32,7 @@ pub fn new_index(_table: AnyLuaValue, lua_key: AnyLuaValue, val: AnyLuaValue)
         let flags: AccessFlags;
         if let Some(reg_field) = reg.get(&key) {
             if let Some((access, _old_arc)) = reg_field.clone().as_object() {
-                if !access.contains(LUA_WRITE) {
+                if !access.contains(AccessFlags::WRITE()) {
                     return Err("Unable to modify that key!");
                 }
                 flags = access;

--- a/src/registry/commands.rs
+++ b/src/registry/commands.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::env;
 use std::io::prelude::*;
 
-use registry::{self, RegistryValue, CommandFn};
+use registry::{self, RegistryField, CommandFn};
 use layout::tree::try_lock_tree;
 use lua::{self, LuaQuery};
 
@@ -18,7 +18,7 @@ pub fn register_defaults() {
     let mut reg = registry::write_lock();
 
     let mut register = |name: &'static str, val: CommandFn| {
-        reg.insert(name.to_string(), RegistryValue::new_command(val));
+        reg.insert(name.to_string(), RegistryField::Command(val));
     };
 
     // Workspace

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -17,7 +17,7 @@ pub use self::types::*; // Export constants too
 #[cfg(test)]
 mod tests;
 
-pub type RegMap = HashMap<String, RegistryValue>;
+pub type RegMap = HashMap<String, RegistryField>;
 
 lazy_static! {
     /// Registry variable for the registry
@@ -49,9 +49,8 @@ pub fn write_lock<'a>() -> RwLockWriteGuard<'a, RegMap> {
     REGISTRY.write().expect("Unable to write to registry!")
 }
 
-
-/// Gets a RegistryValue enum with the specified name
-pub fn get_value<K>(name: &K) -> Option<RegistryValue>
+/// Gets a RegistryField enum with the specified name
+pub fn get_value<K>(name: &K) -> Option<RegistryField>
     where String: Borrow<K>, K: Hash + Eq + Display {
     trace!("> get_value: {}", name);
     // clone() will either clone an Arc or an Arc+AccessFlags
@@ -64,27 +63,36 @@ pub fn get_command<K>(name: &K) -> Result<CommandFn, RegistryError>
     trace!("< get_command: {}", name);
     get_value(name).ok_or(RegistryError::KeyNotFound)
         .and_then(|val| match val {
-        RegistryValue::Command(com) => Ok(com),
+        RegistryField::Command(com) => Ok(com),
         _ => Err(RegistryError::WrongKeyType)
     })
+}
+
+/// Gets a data type from the registry, returning a reference to the property
+/// method if the field is a property.
+pub fn get_data<K>(name: &K) -> Result<RegistryGetData, RegistryError>
+where String: Borrow<K>, K: Hash + Eq + Display {
+    get_value(name).ok_or(RegistryError::KeyNotFound)
+        .and_then(|val| match val {
+            RegistryField::Object { flags, data } =>
+                RegistryGetData::Object(flags, data),
+            RegistryField::Property { get, .. } =>
+                RegistryGetData::Property(get),
+            _ => Err(RegistryError::WrongKeyType)
+        })
 }
 
 /// Gets a Json object from a registry key
 pub fn get_json<K>(name: &K) -> Result<(AccessFlags, Arc<Json>), RegistryError>
 where String: Borrow<K>, K: Hash + Eq + Display {
-    trace!("< get_json: {}", name);
-    get_value(name).ok_or(RegistryError::KeyNotFound)
-        .and_then(|val| match val {
-            RegistryValue::Object { flags, data } =>
-                Ok((flags, data)),
-            _ => Err(RegistryError::WrongKeyType)
-        })
+    get_data(name).ok_or(RegistryError::KeyNotFound)
+        .and_then(|val| val.resolve())
 }
 
 /// Gets an object from the registry, decoding its internal Json
-/// representation.
+/// representation or invoking its command.
 #[allow(dead_code)]
-pub fn get_data<K, T>(name: &K) -> Result<(AccessFlags, T), RegistryError>
+pub fn get_struct<K, T>(name: &K) -> Result<(AccessFlags, T), RegistryError>
     where T: Decodable, String: Borrow<K>, K: Hash + Eq + Display {
     trace!("< < get_data: {}", name);
     get_json(name).and_then(|(flags, obj)| {
@@ -95,31 +103,49 @@ pub fn get_data<K, T>(name: &K) -> Result<(AccessFlags, T), RegistryError>
     })
 }
 
-/// Set a value to the given RegistryValue
+/// Set a value to the given RegistryField
 #[allow(dead_code)]
-pub fn set(key: String, value: RegistryValue) {
-    trace!("> set: {} to {:?}", key, &value);
-    write_lock().insert(key, value);
+pub fn set_field(key: String, value: RegistryField)
+                 -> Result<Option<RegistryField>, RegistryError> {
+    trace!("set: {} to {:?}", key, &value);
+    Ok(write_lock().insert(key, value))
 }
 
 /// Set a command to the given Command
 #[allow(dead_code)]
 pub fn set_command(key: String, command: CommandFn) {
-    trace!("< set_command: {}", key);
-    set(key, RegistryValue::Command(command))
+    set(key, RegistryField::Command(command))
 }
 
 /// Set a value to the given JSON value.
-pub fn set_json(key: String, flags: AccessFlags, json: Json) {
-    trace!("< set_json: {}", key);
-    set(key, RegistryValue::new_json(flags, json))
+pub fn set_json(key: String, flags: AccessFlags, json: Json)
+                -> Result<Option<RegistryField>, RegistryError> {
+    set(key, RegistryField::new_json(flags, json))
+}
+
+/// Sets a value 
+pub fn set_json_property(key: String, flags: AccessFlags, json: Json)
+                         -> Result<Option<Json, SetFn>, RegistryError> {
+    let mut reg = write_lock();
+    let field = reg.entry(key).or_insert(RegistryField::Object {
+        flags: flags, json: Arc::new(json) });
+    match field {
+        &RegistryField::Property { set, .. } => Ok(Some(set.clone())),
+        &RegistryField::Object { .. } => Ok(None),
+        _ => Err(RegistryError::WrongKeyType)
+    }
+
 }
 
 /// Sets a value to the given data, to be encoded into JSON
 #[allow(dead_code)]
-pub fn set_data<T: ToJson>(key: String, access: AccessFlags, val: T) {
-    trace!("< < set_data: {}", key);
+pub fn set_struct<T: ToJson>(key: String, access: AccessFlags, val: T) {
     set_json(key, access, val.to_json())
+}
+
+/// Binds properties to a field of the registry
+pub fn set_property(key: String, get: GetFn, set: SetFn) {
+    set(key, RegistryField::new_property(get, set))
 }
 
 /// Whether this map contains a key of any type

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -93,6 +93,7 @@ where String: Borrow<K>, K: Hash + Eq + Display {
 }
 
 /// Get a Rust structure from the registry
+#[allow(dead_code)]
 pub fn get_struct<K, T>(name: &K) -> RegistryResult<(AccessFlags, T)>
 where String: Borrow <K>, K: Hash + Eq + Display, T: Decodable {
     get_json(name).and_then(|(flags, json)|
@@ -139,6 +140,7 @@ pub fn set_command(key: String, command: CommandFn)
 }
 
 /// Set a value to the given JSON value.
+#[allow(dead_code)]
 pub fn set_json(key: String, flags: AccessFlags, json: Json)
                 -> RegistryResult<Option<(AccessFlags, Arc<Json>)>> {
     let func: SetFn;
@@ -174,6 +176,8 @@ pub fn set_json(key: String, flags: AccessFlags, json: Json)
     return Ok(None);
 }
 
+/// Set an object/property in the registry to a value using a ToJson.
+#[allow(dead_code)]
 pub fn set_struct<T: ToJson>(key: String, flags: AccessFlags, value: T)
                              -> RegistryResult<Option<(AccessFlags, Arc<Json>)>> {
     set_json(key, flags, value.to_json())
@@ -211,6 +215,7 @@ pub fn set_with_property(key: String, flags: AccessFlags, json: Json)
 }
 
 /// Binds properties to a field of the registry
+#[allow(dead_code)]
 pub fn set_property_field(key: String, get_fn: Option<GetFn>, set_fn: Option<SetFn>)
                           -> RegistryResult<Option<RegistryField>> {
     set_field(key, RegistryField::Property { get: get_fn, set: set_fn })

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -129,6 +129,7 @@ pub fn set_field(key: String, value: RegistryField)
 }
 
 /// Set a command to the given Command
+#[allow(dead_code)]
 pub fn set_command(key: String, command: CommandFn)
                    -> RegistryResult<Option<CommandFn>> {
     set_field(key, RegistryField::Command(command))
@@ -179,6 +180,7 @@ pub fn set_struct<T: ToJson>(key: String, flags: AccessFlags, value: T)
 }
 
 /// Sets a value for a given Json value, optionally returning the associated property.
+#[allow(dead_code)]
 pub fn set_with_property(key: String, flags: AccessFlags, json: Json)
                          -> RegistryResult<Option<(Json, SetFn)>> {
     let mut reg = write_lock();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -162,7 +162,7 @@ pub fn set_json(key: String, flags: AccessFlags, json: Json)
                 match entry.get().clone().as_property_set() {
                     Some(func) => {
                         func(json);
-                        return;
+                        return Ok(None);
                     }
                     None => return Err(RegistryError::InvalidOperation)
                 }

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -3,7 +3,6 @@
 use std::sync::{mpsc, Arc};
 use std::time::Duration;
 use std::thread;
-use std::ops::Deref;
 
 use rustc_serialize::Decodable;
 use rustc_serialize::json::{Json, ToJson};
@@ -39,12 +38,12 @@ fn add_keys() {
     let numbers = vec![1, 2, 3, 4, 5];
     let point = Point::new(-11, 12);
 
-    registry::set_struct("test_num".to_string(), LUA_READ, num.to_json());
-    registry::set_struct("test_double".to_string(), LUA_READ, double);
-    registry::set_struct("test_string".to_string(), LUA_READ, string.clone());
-    registry::set_struct("test_numbers".to_string(), LUA_READ, numbers.clone());
-    registry::set_struct("test_point".to_string(), LUA_READ, point.clone());
-    registry::set_property_field("test_func".to_string(), Some(Arc::new(prop_get)), None);
+    registry::set_struct("test_num".to_string(), LUA_READ, num.to_json()).expect(ERR);
+    registry::set_struct("test_double".to_string(), LUA_READ, double).expect(ERR);
+    registry::set_struct("test_string".to_string(), LUA_READ, string.clone()).expect(ERR);
+    registry::set_struct("test_numbers".to_string(), LUA_READ, numbers.clone()).expect(ERR);
+    registry::set_struct("test_point".to_string(), LUA_READ, point.clone()).expect(ERR);
+    registry::set_property_field("test_func".to_string(), Some(Arc::new(prop_get)), None).expect(ERR);
 }
 
 #[test]
@@ -79,9 +78,9 @@ fn keys_equal() {
 #[test]
 fn key_perms() {
     thread::sleep(Duration::from_millis(240));
-    registry::set_struct("perm_none".to_string(), LUA_PRIVATE, 0);
-    registry::set_struct("perm_read".to_string(), LUA_READ, 1);
-    registry::set_struct("perm_write".to_string(), LUA_WRITE, 2);
+    registry::set_struct("perm_none".to_string(), LUA_PRIVATE, 0).expect(ERR);
+    registry::set_struct("perm_read".to_string(), LUA_READ, 1).expect(ERR);
+    registry::set_struct("perm_write".to_string(), LUA_WRITE, 2).expect(ERR);
 
     assert_eq!(get_struct::<_, i32>(&"perm_none".to_string()).expect(ERR).0, LUA_PRIVATE);
     assert_eq!(get_struct::<_, i32>(&"perm_read".to_string()).expect(ERR).0, LUA_READ);

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -7,7 +7,7 @@ use rustc_serialize::Decodable;
 use rustc_serialize::json::ToJson;
 
 use registry;
-use registry::{LUA_READ, LUA_WRITE, LUA_PRIVATE, get_data};
+use registry::{LUA_READ, LUA_WRITE, LUA_PRIVATE, get_struct};
 
 json_convertible! {
     #[derive(Debug, Clone, Eq, PartialEq)]
@@ -27,11 +27,11 @@ fn add_keys() {
     let numbers = vec![1, 2, 3, 4, 5];
     let point = Point { x: -11, y: 12 };
 
-    registry::set_data("test_num".to_string(), LUA_READ, num);
-    registry::set_data("test_double".to_string(), LUA_READ, double);
-    registry::set_data("test_string".to_string(), LUA_READ, string.clone());
-    registry::set_data("test_numbers".to_string(), LUA_READ, numbers.clone());
-    registry::set_data("test_point".to_string(), LUA_READ, point.clone());
+    registry::set_struct("test_num".to_string(), LUA_READ, num.to_json());
+    registry::set_struct("test_double".to_string(), LUA_READ, double);
+    registry::set_struct("test_string".to_string(), LUA_READ, string.clone());
+    registry::set_struct("test_numbers".to_string(), LUA_READ, numbers.clone());
+    registry::set_struct("test_point".to_string(), LUA_READ, point.clone());
 
     assert!(registry::contains_key(&"test_num".to_string()));
     assert!(registry::contains_key(&"test_double".to_string()));
@@ -39,24 +39,24 @@ fn add_keys() {
     assert!(registry::contains_key(&"test_numbers".to_string()));
     assert!(registry::contains_key(&"test_point".to_string()));
 
-    assert_eq!(get_data::<_, i32>(&"test_num".to_string()).expect(ERR).1, num);
-    assert_eq!(get_data::<_, f64>(&"test_double".to_string()).expect(ERR).1, double);
-    assert_eq!(get_data::<_,String>(&"test_string".to_string()).expect(ERR).1, string);
-    assert_eq!(get_data::<_, Vec<i32>>(&"test_numbers".to_string()).expect(ERR).1,
+    assert_eq!(get_struct::<_, i32>(&"test_num".to_string()).expect(ERR).1, num);
+    assert_eq!(get_struct::<_, f64>(&"test_double".to_string()).expect(ERR).1, double);
+    assert_eq!(get_struct::<_,String>(&"test_string".to_string()).expect(ERR).1, string);
+    assert_eq!(get_struct::<_, Vec<i32>>(&"test_numbers".to_string()).expect(ERR).1,
                numbers);
-    assert_eq!(get_data::<_, Point>(&"test_point".to_string()).expect(ERR).1, point);
+    assert_eq!(get_struct::<_, Point>(&"test_point".to_string()).expect(ERR).1, point);
 
 }
 
 #[test]
 fn lua_perms() {
-    registry::set_data("perm_none".to_string(), LUA_PRIVATE, 0);
-    registry::set_data("perm_read".to_string(), LUA_READ, 1);
-    registry::set_data("perm_write".to_string(), LUA_WRITE, 2);
+    registry::set_struct("perm_none".to_string(), LUA_PRIVATE, 0);
+    registry::set_struct("perm_read".to_string(), LUA_READ, 1);
+    registry::set_struct("perm_write".to_string(), LUA_WRITE, 2);
 
-    assert_eq!(get_data::<_, i32>(&"perm_none".to_string()).expect(ERR).0, LUA_PRIVATE);
-    assert_eq!(get_data::<_, i32>(&"perm_read".to_string()).expect(ERR).0, LUA_READ);
-    assert_eq!(get_data::<_, i32>(&"perm_write".to_string()).expect(ERR).0, LUA_WRITE);
+    assert_eq!(get_struct::<_, i32>(&"perm_none".to_string()).expect(ERR).0, LUA_PRIVATE);
+    assert_eq!(get_struct::<_, i32>(&"perm_read".to_string()).expect(ERR).0, LUA_READ);
+    assert_eq!(get_struct::<_, i32>(&"perm_write".to_string()).expect(ERR).0, LUA_WRITE);
 }
 
 #[test]
@@ -102,7 +102,7 @@ fn multithreaded() {
 fn read_thread<T>(name: String, in_val: T, sender: mpsc::Sender<bool>)
 where T: ::std::fmt::Debug + Decodable + PartialEq {
     for _ in 1 .. 50 {
-        if let Ok(acc_val) = get_data::<_, T>(&name) {
+        if let Ok(acc_val) = get_struct::<_, T>(&name) {
             let (acc, val) = acc_val;
             assert!(acc.contains(LUA_READ));
             assert_eq!(val, in_val);

--- a/src/registry/tests.rs
+++ b/src/registry/tests.rs
@@ -1,13 +1,15 @@
 //! Tests for the registry
 
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
 use std::thread;
+use std::ops::Deref;
 
 use rustc_serialize::Decodable;
-use rustc_serialize::json::ToJson;
+use rustc_serialize::json::{Json, ToJson};
 
 use registry;
-use registry::{LUA_READ, LUA_WRITE, LUA_PRIVATE, get_struct};
+use registry::{AccessFlags, LUA_READ, LUA_WRITE, LUA_PRIVATE, get_struct};
 
 json_convertible! {
     #[derive(Debug, Clone, Eq, PartialEq)]
@@ -17,7 +19,17 @@ json_convertible! {
     }
 }
 
+impl Point {
+    fn new(x: i32, y: i32) -> Point {
+        Point { x: x, y: y }
+    }
+}
+
 const ERR: &'static str = "Key which was added no longer exists!";
+
+fn prop_get() -> Json {
+    Point::new(0, 0).to_json()
+}
 
 #[test]
 fn add_keys() {
@@ -25,31 +37,48 @@ fn add_keys() {
     let double = -392f64;
     let string = "Hello world".to_string();
     let numbers = vec![1, 2, 3, 4, 5];
-    let point = Point { x: -11, y: 12 };
+    let point = Point::new(-11, 12);
 
     registry::set_struct("test_num".to_string(), LUA_READ, num.to_json());
     registry::set_struct("test_double".to_string(), LUA_READ, double);
     registry::set_struct("test_string".to_string(), LUA_READ, string.clone());
     registry::set_struct("test_numbers".to_string(), LUA_READ, numbers.clone());
     registry::set_struct("test_point".to_string(), LUA_READ, point.clone());
+    registry::set_property_field("test_func".to_string(), Some(Arc::new(prop_get)), None);
+}
 
-    assert!(registry::contains_key(&"test_num".to_string()));
-    assert!(registry::contains_key(&"test_double".to_string()));
-    assert!(registry::contains_key(&"test_string".to_string()));
-    assert!(registry::contains_key(&"test_numbers".to_string()));
-    assert!(registry::contains_key(&"test_point".to_string()));
+#[test]
+fn contains_keys() {
+    thread::sleep(Duration::from_millis(240));
+    assert!(registry::contains_key(&"test_num".to_string()), "num");
+    assert!(registry::contains_key(&"test_double".to_string()), "double");
+    assert!(registry::contains_key(&"test_string".to_string()), "string");
+    assert!(registry::contains_key(&"test_numbers".to_string()), "numbers");
+    assert!(registry::contains_key(&"test_point".to_string()), "point");
+    assert!(registry::contains_key(&"test_func".to_string()), "func");
+}
 
+#[test]
+fn keys_equal() {
+    let num = 1i32;
+    let double = -392f64;
+    let string = "Hello world".to_string();
+    let numbers = vec![1, 2, 3, 4, 5];
+    let point = Point::new(-11, 12);
+    thread::sleep(Duration::from_millis(240));
     assert_eq!(get_struct::<_, i32>(&"test_num".to_string()).expect(ERR).1, num);
     assert_eq!(get_struct::<_, f64>(&"test_double".to_string()).expect(ERR).1, double);
     assert_eq!(get_struct::<_,String>(&"test_string".to_string()).expect(ERR).1, string);
     assert_eq!(get_struct::<_, Vec<i32>>(&"test_numbers".to_string()).expect(ERR).1,
                numbers);
     assert_eq!(get_struct::<_, Point>(&"test_point".to_string()).expect(ERR).1, point);
-
+    assert_eq!(get_struct::<_, Point>(&"test_func".to_string()).expect(ERR).1,
+               Point::new(0, 0));
 }
 
 #[test]
-fn lua_perms() {
+fn key_perms() {
+    thread::sleep(Duration::from_millis(240));
     registry::set_struct("perm_none".to_string(), LUA_PRIVATE, 0);
     registry::set_struct("perm_read".to_string(), LUA_READ, 1);
     registry::set_struct("perm_write".to_string(), LUA_WRITE, 2);
@@ -57,11 +86,11 @@ fn lua_perms() {
     assert_eq!(get_struct::<_, i32>(&"perm_none".to_string()).expect(ERR).0, LUA_PRIVATE);
     assert_eq!(get_struct::<_, i32>(&"perm_read".to_string()).expect(ERR).0, LUA_READ);
     assert_eq!(get_struct::<_, i32>(&"perm_write".to_string()).expect(ERR).0, LUA_WRITE);
+    assert_eq!(registry::get_json(&"test_func".to_string()).expect(ERR).0, AccessFlags::all());
 }
 
 #[test]
 fn multithreaded() {
-    use std::time::Duration;
     let (tx, rx) = mpsc::channel();
     thread::sleep(Duration::from_millis(240));
     let num = 1i32;

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -9,14 +9,23 @@ use rustc_serialize::json::Json;
 bitflags! {
     /// Access permissions for items in the registry
     pub flags AccessFlags: u8 {
-        #[allow(dead_code)]
-        /// Default flags
-        const LUA_PRIVATE = 0,
-        /// Lua thread can read the data
-        const LUA_READ    = 1 << 0,
-        /// Lua thread can write to the data
-        const LUA_WRITE   = 1 << 1,
+        /// Clients can read/get the data
+        const READ    = 1 << 0,
+        /// Clients can write/set the data
+        const WRITE   = 1 << 1,
     }
+}
+
+impl AccessFlags {
+    /// Read permissions
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn READ() -> AccessFlags { READ }
+
+    /// Write permissions
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn WRITE() -> AccessFlags { WRITE }
 }
 
 
@@ -118,8 +127,8 @@ impl RegistryField {
             &RegistryField::Object { ref flags, .. } => Some(flags.clone()),
             &RegistryField::Property { ref get, ref set } => {
                 let mut flags = AccessFlags::empty();
-                if get.is_some() { flags.insert(LUA_READ); }
-                if set.is_some() { flags.insert(LUA_WRITE); }
+                if get.is_some() { flags.insert(AccessFlags::READ()); }
+                if set.is_some() { flags.insert(AccessFlags::WRITE()); }
                 Some(flags)
             },
             _ => None

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::fmt::{Debug, Formatter};
 use std::fmt::Result as FmtResult;
 
-use rustc_serialize::json::{Json, ToJson};
+use rustc_serialize::json::Json;
 
 bitflags! {
     /// Access permissions for items in the registry
@@ -134,6 +134,7 @@ impl RegistryField {
     }
 
     /// Attempts to access the RegistryField as a file
+    #[allow(dead_code)]
     pub fn get_data(&self) -> Option<RegistryGetData> {
         match *self {
             RegistryField::Object { ref flags, ref data } =>
@@ -145,6 +146,7 @@ impl RegistryField {
     }
 
     /// Converts this RegistryField to maybe a command
+    #[allow(dead_code)]
     pub fn as_command(self) -> Option<CommandFn> {
         match self {
             RegistryField::Command(com) => Some(com),
@@ -166,6 +168,7 @@ impl RegistryField {
         }
     }
 
+    #[allow(dead_code)]
     pub fn as_property_get(self) -> Option<GetFn> {
         self.as_property().and_then(|(maybe_get, _)| maybe_get)
     }
@@ -193,6 +196,7 @@ impl RegistryGetData {
         }
     }
 
+    #[allow(dead_code)]
     pub fn get_type(&self) -> FieldType {
         match self {
             &RegistryGetData::Property(_) => FieldType::Property,

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -98,6 +98,7 @@ impl Debug for RegistryGetData {
 }
 
 impl FieldType {
+    /// Whether a field of this type can be changed by a field of type other.
     pub fn can_set_from(self, other: FieldType) -> bool {
         match self {
             FieldType::Command => other == FieldType::Command,
@@ -154,6 +155,7 @@ impl RegistryField {
         }
     }
 
+    /// Converts this RegistryField to maybe an object. Does not call property methods.
     pub fn as_object(self) -> Option<(AccessFlags, Arc<Json>)> {
         match self {
             RegistryField::Object { flags, data } => Some((flags, data)),
@@ -161,6 +163,7 @@ impl RegistryField {
         }
     }
 
+    /// Gets this field as maybe a property with maybe a getter and setter.
     pub fn as_property(self) -> Option<(Option<GetFn>, Option<SetFn>)> {
         match self {
             RegistryField::Property { get, set } => Some((get, set)),
@@ -168,11 +171,13 @@ impl RegistryField {
         }
     }
 
+    /// Returns the getter, if this field is a property with a getter.
     #[allow(dead_code)]
     pub fn as_property_get(self) -> Option<GetFn> {
         self.as_property().and_then(|(maybe_get, _)| maybe_get)
     }
 
+    /// Returns a setter if this field is a property with a setter.
     pub fn as_property_set(self) -> Option<SetFn> {
         self.as_property().and_then(|(_, maybe_set)| maybe_set)
     }
@@ -188,6 +193,10 @@ impl RegistryField {
 }
 
 impl RegistryGetData {
+    /// Collapses the waveform.
+    ///
+    /// If this is a Json, returns the Json data. If this is a property, runs the
+    /// method and returns the output.
     pub fn resolve(self) -> (AccessFlags, Arc<Json>) {
         match self {
             RegistryGetData::Object(flags, data) => (flags, data),
@@ -196,6 +205,7 @@ impl RegistryGetData {
         }
     }
 
+    /// Gets the FieldType of this GetData (property or object)
     #[allow(dead_code)]
     pub fn get_type(&self) -> FieldType {
         match self {

--- a/src/registry/types.rs
+++ b/src/registry/types.rs
@@ -22,9 +22,19 @@ bitflags! {
 /// Command type for Rust function
 pub type CommandFn = Arc<Fn() + Send + Sync>;
 
+/// Function which will yield an object
+pub type GetFn = Arc<Fn() -> Json + Send + Sync>;
+
+/// Function which will set an object
+pub type SetFn = Arc<Fn(Json) + Send + Sync>;
+
+/// Enum of types of registry fields
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum FieldType { Object, Property, Command }
+
 /// Data which can be stored in the registry
 #[derive(Clone)]
-pub enum RegistryValue {
+pub enum RegistryField {
     /// An object with permission flags
     Object {
         /// Permission flags for Lua get/setting the value
@@ -32,70 +42,142 @@ pub enum RegistryValue {
         /// Data associated with this value
         data: Arc<Json>
     },
+    /// A registry value whose get and set maps to other Rust code
+    Property {
+        /// Method called to set a property
+        get: GetFn,
+        /// Method called to set a property
+        set: SetFn
+    },
     /// A command
     Command(CommandFn)
 }
 
-impl Debug for RegistryValue {
+/// Result of what can be accessed from a registry value.
+#[derive(Clone)]
+pub enum RegistryGetData {
+    /// An object in the registry
+    Object(AccessFlags, Arc<Json>),
+    /// Get field of a property in the registry
+    Property(GetFn)
+}
+
+impl Debug for RegistryField {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         match self {
-            &RegistryValue::Object { ref flags, ref data } =>
-                f.debug_struct("RegistryValue::Object")
+            &RegistryField::Object { ref flags, ref data } =>
+                f.debug_struct("RegistryField::Object")
                 .field("flags", flags as &Debug)
                 .field("data", data as &Debug).finish(),
-            &RegistryValue::Command(_) =>
-                write!(f, "RegistryValue::Command(...)")
+            &RegistryField::Property { .. } =>
+                write!(f, "RegistryField::Property(...)"),
+            &RegistryField::Command(_) =>
+                write!(f, "RegistryField::Command(...)")
         }
     }
 }
 
-impl RegistryValue {
+impl Debug for RegistryGetData {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        match self {
+            &RegistryGetData::Object { ref flags, ref data } =>
+                f.debug_struct("RegistryGetData::Object")
+                .field("flags", flags as &Debug)
+                .field("data", data as &Debug).finish(),
+            &RegistryField::Property { .. } =>
+                write!(f, "RegistryGetData::Property(...)")
+        }
+    }
+}
+
+impl FieldType {
+    pub fn can_set_from(self, other: FieldType) -> bool {
+        match self {
+            FieldType::Command => other == FieldType::Command,
+            FieldType::Property =>
+                other == FieldType::Object ||
+                other == FieldType::Property,
+            FieldType::Object => other == FieldType::Object
+        }
+    }
+}
+
+impl RegistryField {
     /// Creates a new registry object with the specified flags
     /// and Rust data to be converted.
     #[allow(dead_code)]
-    pub fn new_value<T: ToJson>(flags: AccessFlags, data: T) -> RegistryValue {
-        RegistryValue::Object {
+    pub fn new_value<T: ToJson>(flags: AccessFlags, data: T) -> RegistryField {
+        RegistryField::Object {
             flags: flags,
             data: Arc::new(data.to_json())
         }
     }
 
     /// Creates a new RegistryFile with the specified Lua data.
-    pub fn new_json(flags: AccessFlags, data: Json) -> RegistryValue {
-        RegistryValue::Object {
+    pub fn new_json(flags: AccessFlags, data: Json) -> RegistryField {
+        RegistryField::Object {
             flags: flags, data: Arc::new(data)
         }
     }
 
     /// Creates a new RegistryCommand with the specified callback.
-    pub fn new_command(com: CommandFn) -> RegistryValue {
-        RegistryValue::Command(com)
+    pub fn new_command(com: CommandFn) -> RegistryField {
+        RegistryField::Command(com)
+    }
+
+    /// Creates a new registry property with the specified getter and setter
+    pub fn new_property(get: GetFn, set: SetFn) -> RegistryField {
+        RegistryField::Property {
+            get: get, set: set
+        }
     }
 
     /// What access the module has to it
     #[allow(dead_code)]
     pub fn get_flags(&self) -> Option<AccessFlags> {
         match self {
-            &RegistryValue::Object { ref flags, .. } => Some(flags.clone()),
+            &RegistryField::Object { ref flags, .. } => Some(flags.clone()),
+            &RegistryField::Property { .. } => Some(AccessFlags::all()),
             _ => None
         }
     }
 
-    /// Attempts to access the RegistryValue as a command
+    /// Attempts to access the RegistryField as a command
     #[allow(dead_code)]
     pub fn get_command(self) -> Option<CommandFn> {
         match self {
-            RegistryValue::Command(com) => Some(com),
+            RegistryField::Command(com) => Some(com),
             _ => None
         }
     }
 
-    /// Attempts to access the RegistryValue as a file
-    pub fn get_data(&self) -> Option<(AccessFlags, Arc<Json>)> {
+    /// Attempts to access the RegistryField as a file
+    pub fn get_data(&self) -> Option<RegistryGetData> {
         match *self {
-            RegistryValue::Object { ref flags, ref data } =>
-                Some((flags.clone(), data.clone())),
+            RegistryField::Object { ref flags, ref data } =>
+                Some(RegistryGetData::Object(flags,clone(), data.clone())),
+            RegistryField::Property { ref get, .. } =>
+                Some(RegistryGetData::Property(get.clone())),
             _ => None
+        }
+    }
+
+    /// Gets the type of this registry field
+    pub fn get_type(&self) -> FieldType {
+        match self {
+            &RegistryField::Object { .. }   => FieldType::Object,
+            &RegistryField::Property { .. } => FieldType::Property,
+            &RegistryField::Command(_)      => FieldType::Command
+        }
+    }
+}
+
+impl RegistryGetData {
+    pub fn resolve(self) -> (AccessFlags, Arc<Json>) {
+        match self {
+            RegistryGetData::Object(flags, data) => (flags, data),
+            RegistryGetData::Property(get) =>
+                (AccessFlags::all(), Arc::new(get()))
         }
     }
 }


### PR DESCRIPTION
Properties were added to the registry! This is similar to programming language properties, and is implemented by registering Rust methods to be called when a registry key is read or written.

- Add `Property` variant to registry values
- Rename `RegistryValue` -> `RegistryField`
- Unify registry return types as `RegistryResult`
- Rename flags to `AccessFlags::{READ, WRITE}`
- Reduce `trace!` spam from using the registry (but add printing of values)
- Rename `registry::{get, set}_data` to `registry::{get, set}_struct`
- Split up registry tests