### PR TITLE
Tiling Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,11 @@ matrix:
   allow_failures:
     - rust: nightly
 notifications:
-  slack: way-cooler:W2vOSvJvgxGi7EiGkZCtvlB6
+  slack:
+    rooms:
+      - way-cooler:W2vOSvJvgxGi7EiGkZCtvlB6#way-cooler
+    on_success: :change
+    on_failure: :change
   email: false
 # load travis-cargo
 before_script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "way-cooler"
 version = "0.2.0"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dummy-rustwlc 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dummy-rustwlc 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hlua 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,7 +28,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dummy-rustwlc"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -80,7 +80,7 @@ pub extern fn view_destroyed(view: WlcView) {
     trace!("view_destroyed: {:?}", view);
     if let Ok(mut tree) = tree::try_lock_tree() {
         tree.remove_view(&view);
-        tree.update_active_of(ContainerType::Container);
+        tree.update_active_of(ContainerType::Workspace);
     } else {
         warn!("Could not delete view {:?}", view);
     }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -62,11 +62,18 @@ pub extern fn output_render_post(output: WlcOutput) {
 pub extern fn view_created(view: WlcView) -> bool {
     trace!("view_created: {:?}: \"{}\"", view, view.get_title());
     let output = view.get_output();
-    view.set_mask(output.get_mask());
     if let Ok(mut tree) = tree::try_lock_tree() {
+        if tree.get_active_container().is_none() {
+            warn!("Could not create view, there is no focus \
+                    so Way-Cooler doesn't know where to put it");
+            return false;
+        }
+        view.set_mask(output.get_mask());
         let v_type = view.get_type();
         if v_type != ViewType::empty() {
             view.focus();
+            // Now focused on something outside the tree, have to unset the active container
+            tree.unset_active_container();
             return true
         }
         tree.add_view(view.clone());

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -44,7 +44,7 @@ pub extern fn output_resolution(output: WlcOutput,
                             old_size_ptr: &Size, new_size_ptr: &Size) {
     trace!("output_resolution: {:?} from  {:?} to {:?}",
            output, *old_size_ptr, *new_size_ptr);
-    // Update the resolution of the output and it's children
+    // Update the resolution of the output and its children
     output.set_resolution(new_size_ptr.clone());
     if let Ok(mut tree) = tree::try_lock_tree() {
         tree.layout_active_of(ContainerType::Output);
@@ -64,28 +64,26 @@ pub extern fn view_created(view: WlcView) -> bool {
     let output = view.get_output();
     if let Ok(mut tree) = tree::try_lock_tree() {
         if tree.get_active_container().is_none() {
-            warn!("Could not create view, there is no focus \
-                    so Way-Cooler doesn't know where to put it");
-            return false;
+            warn!("Could not create view, so there is no focus and \
+                    way-cooler doesn't know where to put it");
+            return false
         }
         view.set_mask(output.get_mask());
         let v_type = view.get_type();
         if v_type != ViewType::empty() {
             view.focus();
-            // Now focused on something outside the tree, have to unset the active container
-            if tree.get_active_container().is_some() {
-                if tree.active_is_root() {
-                    return true;
-                }
+            // Now focused on something outside the tree,
+            // have to unset the active container
+            if !tree.active_is_root() {
+                tree.unset_active_container();
             }
-            tree.unset_active_container();
             return true
         }
         tree.add_view(view.clone());
         tree.normalize_view(view.clone());
         tree.layout_active_of(ContainerType::Container);
         tree.set_active_container(view.clone());
-        true
+        return true
     } else {
         false
     }
@@ -121,7 +119,7 @@ pub extern fn view_move_to_output(current: WlcView,
 
 pub extern fn view_request_geometry(view: WlcView, geometry: &Geometry) {
     trace!("view_request_geometry: {:?} wants {:?}", view, geometry);
-    warn!("Denying request");
+    warn!("Denying view {} request for size", view.get_title());
 }
 
 pub extern fn view_request_state(view: WlcView, state: ViewState, handled: bool) {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -72,7 +72,6 @@ pub extern fn view_created(view: WlcView) -> bool {
         tree.set_active_container(view.clone());
         drop(tree);
         view.set_mask(output.get_mask());
-        view.bring_to_front();
         true
     } else {
         false

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -64,13 +64,13 @@ pub extern fn view_created(view: WlcView) -> bool {
     let output = view.get_output();
     if let Ok(mut tree) = tree::try_lock_tree() {
         let v_type = view.get_type();
-        if v_type == ViewType::empty() {
-            tree.add_view(view.clone());
+        if v_type != ViewType::empty() {
+            return true
         }
+        tree.add_view(view.clone());
         tree.normalize_view(view.clone());
         tree.layout_active_of(ContainerType::Container);
         tree.set_active_container(view.clone());
-        drop(tree);
         view.set_mask(output.get_mask());
         true
     } else {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -62,16 +62,17 @@ pub extern fn output_render_post(output: WlcOutput) {
 pub extern fn view_created(view: WlcView) -> bool {
     trace!("view_created: {:?}: \"{}\"", view, view.get_title());
     let output = view.get_output();
+    view.set_mask(output.get_mask());
     if let Ok(mut tree) = tree::try_lock_tree() {
         let v_type = view.get_type();
         if v_type != ViewType::empty() {
+            view.focus();
             return true
         }
         tree.add_view(view.clone());
         tree.normalize_view(view.clone());
         tree.layout_active_of(ContainerType::Container);
         tree.set_active_container(view.clone());
-        view.set_mask(output.get_mask());
         true
     } else {
         false

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -63,7 +63,10 @@ pub extern fn view_created(view: WlcView) -> bool {
     trace!("view_created: {:?}: \"{}\"", view, view.get_title());
     let output = view.get_output();
     if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.add_view(view.clone());
+        let v_type = view.get_type();
+        if v_type == ViewType::empty() {
+            tree.add_view(view.clone());
+        }
         tree.normalize_view(view.clone());
         tree.layout_active_of(ContainerType::Container);
         drop(tree);

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -47,7 +47,7 @@ pub extern fn output_resolution(output: WlcOutput,
     // Update the resolution of the output and it's children
     output.set_resolution(new_size_ptr.clone());
     if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.update_active_of(ContainerType::Output);
+        tree.layout_active_of(ContainerType::Output);
     }
 }
 /*
@@ -65,7 +65,7 @@ pub extern fn view_created(view: WlcView) -> bool {
     if let Ok(mut tree) = tree::try_lock_tree() {
         tree.add_view(view.clone());
         tree.normalize_view(view.clone());
-        tree.update_active_of(ContainerType::Container);
+        tree.layout_active_of(ContainerType::Container);
         drop(tree);
         view.set_mask(output.get_mask());
         view.bring_to_front();
@@ -80,7 +80,7 @@ pub extern fn view_destroyed(view: WlcView) {
     trace!("view_destroyed: {:?}", view);
     if let Ok(mut tree) = tree::try_lock_tree() {
         tree.remove_view(&view);
-        tree.update_active_of(ContainerType::Workspace);
+        tree.layout_active_of(ContainerType::Workspace);
     } else {
         warn!("Could not delete view {:?}", view);
     }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -69,10 +69,10 @@ pub extern fn view_created(view: WlcView) -> bool {
         }
         tree.normalize_view(view.clone());
         tree.layout_active_of(ContainerType::Container);
+        tree.set_active_container(view.clone());
         drop(tree);
         view.set_mask(output.get_mask());
         view.bring_to_front();
-        view.focus();
         true
     } else {
         false

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -73,6 +73,11 @@ pub extern fn view_created(view: WlcView) -> bool {
         if v_type != ViewType::empty() {
             view.focus();
             // Now focused on something outside the tree, have to unset the active container
+            if tree.get_active_container().is_some() {
+                if tree.active_is_root() {
+                    return true;
+                }
+            }
             tree.unset_active_container();
             return true
         }

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -30,7 +30,7 @@ pub fn register_defaults() {
     register("dmenu_eval", Arc::new(dmenu_eval));
     register("dmenu_lua_dofile", Arc::new(dmenu_lua_dofile));
 
-    /// Generate switch_workspace methods and register them in $map
+    /// Generate switch_workspace methods and register them
     macro_rules! gen_switch_workspace {
         ( $($b:ident, $n:expr);+ ) => {
             $(fn $b() {
@@ -40,6 +40,19 @@ pub fn register_defaults() {
                 }
             }
             register(stringify!($b), Arc::new($b)); )+
+        }
+    }
+
+    //// Generates move_to_workspace methods and registers them
+    macro_rules! gen_move_to_workspace {
+        ( $($b:ident, $n:expr);+ ) => {
+            $(fn $b() {
+                trace!("Switching to workspace {}", $n);
+                if let Ok(mut tree) = try_lock_tree() {
+                    tree.send_active_to_workspace(&$n.to_string());
+                }
+            }
+              register(stringify!($b), Arc::new($b)); )+
         }
     }
 
@@ -54,6 +67,17 @@ pub fn register_defaults() {
                           switch_workspace_8, "8";
                           switch_workspace_9, "9";
                           switch_workspace_0, "0");
+
+    gen_move_to_workspace!(move_to_workspace_1, "1";
+                           move_to_workspace_2, "2";
+                           move_to_workspace_3, "3";
+                           move_to_workspace_4, "4";
+                           move_to_workspace_5, "5";
+                           move_to_workspace_6, "6";
+                           move_to_workspace_7, "7";
+                           move_to_workspace_8, "8";
+                           move_to_workspace_9, "9";
+                           move_to_workspace_0, "0");
 
     register("horizontal_vertical_switch", Arc::new(tile_switch));
     register("split_vertical", Arc::new(split_vertical));

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -86,11 +86,18 @@ pub fn register_defaults() {
     register("focus_right", Arc::new(focus_right));
     register("focus_up", Arc::new(focus_up));
     register("focus_down", Arc::new(focus_down));
+    register("remove_active", Arc::new(remove_active))
 
 }
 
 // All of the methods defined should be registered.
 #[deny(dead_code)]
+
+fn remove_active() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.remove_active();
+    }
+}
 
 fn tile_switch() {
     if let Ok(mut tree) = try_lock_tree() {

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -7,7 +7,8 @@ use std::env;
 use std::io::prelude::*;
 
 use commands::{self, CommandFn};
-use layout::tree::try_lock_tree;
+use layout::tree::{Direction, try_lock_tree};
+use layout::container::{ContainerType, Layout};
 use lua::{self, LuaQuery};
 
 /// Register the default commands in the API.
@@ -21,7 +22,6 @@ pub fn register_defaults() {
         coms.insert(name.to_string(), val);
     };
 
-    // Workspace
     register("quit", Arc::new(quit));
     register("launch_terminal", Arc::new(launch_terminal));
     register("launch_dmenu", Arc::new(launch_dmenu));
@@ -29,9 +29,6 @@ pub fn register_defaults() {
 
     register("dmenu_eval", Arc::new(dmenu_eval));
     register("dmenu_lua_dofile", Arc::new(dmenu_lua_dofile));
-
-    //register("workspace_left", workspace_left);
-    //register("workspace_right", workspace_right);
 
     /// Generate switch_workspace methods and register them in $map
     macro_rules! gen_switch_workspace {
@@ -58,10 +55,61 @@ pub fn register_defaults() {
                           switch_workspace_9, "9";
                           switch_workspace_0, "0");
 
+    register("horizontal_vertical_switch", Arc::new(tile_switch));
+    register("split_vertical", Arc::new(split_vertical));
+    register("split_horizontal", Arc::new(split_horizontal));
+    register("focus_left", Arc::new(focus_left));
+    register("focus_right", Arc::new(focus_right));
+    register("focus_up", Arc::new(focus_up));
+    register("focus_down", Arc::new(focus_down));
+
 }
 
 // All of the methods defined should be registered.
 #[deny(dead_code)]
+
+fn tile_switch() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.toggle_active_horizontal();
+        tree.layout_active_of(ContainerType::Workspace);
+    }
+}
+
+fn split_vertical() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.toggle_active_layout(Layout::Vertical);
+    }
+}
+
+fn split_horizontal() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.toggle_active_layout(Layout::Horizontal);
+    }
+}
+
+fn focus_left() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.move_focus(Direction::Left);
+    }
+}
+
+fn focus_right() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.move_focus(Direction::Right);
+    }
+}
+
+fn focus_up() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.move_focus(Direction::Up);
+    }
+}
+
+fn focus_down() {
+    if let Ok(mut tree) = try_lock_tree() {
+        tree.move_focus(Direction::Down);
+    }
+}
 
 fn launch_terminal() {
     let term = env::var("WAYLAND_TERMINAL")

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -154,8 +154,6 @@ pub fn on_pointer_button(view: WlcView, _time: u32, mods: &KeyboardModifiers, bu
                          state: ButtonState, point: &Point) -> bool {
     if state == ButtonState::Pressed {
         if !view.is_root() {
-            view.focus();
-            view.bring_to_front();
             let mut tree = tree::try_lock_tree().expect(ERR_TREE);
             tree.set_active_container(view.clone());
         }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -149,9 +149,9 @@ pub fn start_interactive_move(view: &WlcView, origin: &Point) -> bool {
 }
 
 /// Performs an operation on a pointer button, to be used in the callback
-#[allow(unused_variables)]
-pub fn on_pointer_button(view: WlcView, _time: u32, mods: &KeyboardModifiers, button: u32,
-                         state: ButtonState, point: &Point) -> bool {
+pub fn on_pointer_button(view: WlcView, _time: u32, _mods: &KeyboardModifiers,
+                         _button: u32, state: ButtonState, _point: &Point)
+                         -> bool {
     if state == ButtonState::Pressed {
         if !view.is_root() {
             let mut tree = tree::try_lock_tree().expect(ERR_TREE);
@@ -162,10 +162,8 @@ pub fn on_pointer_button(view: WlcView, _time: u32, mods: &KeyboardModifiers, bu
         stop_interactive_action();
     }
 
-    {
-        let comp = COMPOSITOR.read().expect(ERR_LOCK);
-        return comp.view.is_some();
-    }
+    let comp = COMPOSITOR.read().expect(ERR_LOCK);
+    return comp.view.is_some()
 }
 
 /// Performs an operation on a pointer motion, to be used in the callback

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -195,7 +195,6 @@ fn start_interactive_action(view: &WlcView, origin: &Point) -> Result<(), &'stat
         }
     }
 
-    view.bring_to_front();
     Ok(())
 }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -13,7 +13,6 @@ lazy_static! {
 
 const ERR_LOCK: &'static str = "Unable to lock compositor!";
 const ERR_TREE: &'static str = "Unable to lock tree!";
-const ERR_GEO: &'static str = "Unable to access view geometry!";
 
 #[derive(Debug, PartialEq)]
 pub struct Compositor {
@@ -74,30 +73,6 @@ enum ClickAction {
     BeginResizing,
     SelectWindow,
 
-}
-
-/// Maximizes the view to the size of the output it sits in
-pub fn set_focused_window_maximized(wlc_view: &WlcView) {
-    let maybe_geometry = wlc_view.get_geometry();
-    if maybe_geometry.is_none() {
-        return;
-    }
-    let geometry = maybe_geometry.expect(ERR_GEO);
-    if start_interactive_action(wlc_view, &geometry.origin).is_err() {
-        return;
-    };
-    {
-        let mut comp = COMPOSITOR.write().expect(ERR_LOCK);
-        if let Some(ref mut view) = comp.view {
-            let output = view.get_output();
-            trace!("Output size of the view: {:?}", output.get_resolution());
-            let output_size = output.get_resolution();
-            let geometry = Geometry { origin: Point { x: 0, y: 0},
-                                        size: output_size.clone() };
-            view.set_geometry(EDGE_NONE, &geometry);
-        }
-    }
-    stop_interactive_action();
 }
 
 /// Makes the compositor no longer track the node to be used in some interaction
@@ -174,24 +149,15 @@ pub fn start_interactive_move(view: &WlcView, origin: &Point) -> bool {
 }
 
 /// Performs an operation on a pointer button, to be used in the callback
+#[allow(unused_variables)]
 pub fn on_pointer_button(view: WlcView, _time: u32, mods: &KeyboardModifiers, button: u32,
                          state: ButtonState, point: &Point) -> bool {
     if state == ButtonState::Pressed {
         if !view.is_root() {
             view.focus();
             view.bring_to_front();
-            if mods.mods.contains(MOD_CTRL) {
-                // Button left, we need to include linux/input.h somehow
-                if button == 0x110 {
-                    start_interactive_move(&view, point);
-                }
-                if button == 0x111 {
-                    start_interactive_resize(&view, ResizeEdge::empty(), point);
-                }
-                if mods.mods.contains(MOD_SHIFT) {
-                    set_focused_window_maximized(&view);
-                }
-            }
+            let mut tree = tree::try_lock_tree().expect(ERR_TREE);
+            tree.set_active_container(view.clone());
         }
     }
     else {
@@ -207,66 +173,6 @@ pub fn on_pointer_button(view: WlcView, _time: u32, mods: &KeyboardModifiers, bu
 /// Performs an operation on a pointer motion, to be used in the callback
 pub fn on_pointer_motion(_view: WlcView, _time: u32, point: &Point) -> bool {
     rustwlc::input::pointer::set_position(point);
-    if let Ok(comp) = COMPOSITOR.read() {
-        if let Some(ref view) = comp.view {
-            let dx = point.x - comp.grab.x;
-            let dy = point.y - comp.grab.y;
-            let mut geo = view.get_geometry().expect(ERR_GEO).clone();
-            if comp.edges.bits() != 0 {
-                let min = Size { w: 80u32, h: 40u32};
-                let mut new_geo = geo.clone();
-
-                if comp.edges.contains(RESIZE_LEFT) {
-                    if dx < 0 {
-                        new_geo.size.w += dx.abs() as u32;
-                    } else {
-                        new_geo.size.w -= dx.abs() as u32;
-                    }
-                    new_geo.origin.x += dx;
-                }
-                else if comp.edges.contains(RESIZE_RIGHT) {
-                    if dx < 0 {
-                        new_geo.size.w -= dx.abs() as u32;
-                    } else {
-                        new_geo.size.w += dx.abs() as u32;
-                    }
-                }
-
-                if comp.edges.contains(RESIZE_TOP) {
-                    if dy < 0 {
-                        new_geo.size.h += dy.abs() as u32;
-                    } else {
-                        new_geo.size.h -= dy.abs() as u32;
-                    }
-                    new_geo.origin.y += dy;
-                }
-                else if comp.edges.contains(RESIZE_BOTTOM) {
-                    if dy < 0 {
-                        new_geo.size.h -= dy.abs() as u32;
-                    } else {
-                        new_geo.size.h += dy.abs() as u32;
-                    }
-                }
-
-                if new_geo.size.w >= min.w {
-                    geo.origin.x = new_geo.origin.x;
-                    geo.size.w = new_geo.size.w;
-                }
-
-                if new_geo.size.h >= min.h {
-                    geo.origin.y = new_geo.origin.y;
-                    geo.size.h = new_geo.size.h;
-                }
-
-                view.set_geometry(comp.edges, &geo);
-            }
-            else {
-                geo.origin.x += dx;
-                geo.origin.y += dy;
-                view.set_geometry(ResizeEdge::empty(), &geo);
-            }
-        }
-    }
     if let Ok(mut comp) = COMPOSITOR.write() {
         comp.grab = point.clone();
         comp.view.is_some()

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -82,11 +82,20 @@ lazy_static! {
             quit_fn, keypress!("Alt", "Escape");
             terminal_fn, keypress!("Alt", "Return");
             dmenu_fn, keypress!("Alt", "d");
-            pointer_fn, keypress!("Alt", "p")
+            pointer_fn, keypress!("Alt", "p");
+            horizontal_vertical_switch_fn, keypress!("Alt", "e")
         }
 
         RwLock::new(map)
     };
+}
+
+fn horizontal_vertical_switch_fn() {
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.toggle_active_horizontal()
+    } else {
+        error!("Could not grab tree")
+    }
 }
 
 fn terminal_fn() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -10,6 +10,7 @@ use rustwlc::types::*; // Need * for bitflags...
 use super::commands;
 use registry::get_command;
 use super::layout::tree;
+use super::layout::container::Layout;
 use super::lua;
 
 /// Register default keypresses to a map
@@ -96,14 +97,14 @@ lazy_static! {
 fn split_vertical() {
     trace!("Splitting vertically");
     if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.active_split_vertical();
+        tree.toggle_active_layout(Layout::Vertical);
     }
 }
 
 fn split_horizontal() {
     trace!("Splitting horizontally");
     if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.active_split_horizontal();
+        tree.toggle_active_layout(Layout::Horizontal);
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -59,7 +59,19 @@ pub fn init() {
         keypress!("Alt", "7") => "switch_workspace_7";
         keypress!("Alt", "8") => "switch_workspace_8";
         keypress!("Alt", "9") => "switch_workspace_9";
-        keypress!("Alt", "0") => "switch_workspace_0"
+        keypress!("Alt", "0") => "switch_workspace_0";
+
+        /* Moving active container to another Workspace key bindings */
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("1")).unwrap() => "move_to_workspace_1";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("2")).unwrap() => "move_to_workspace_2";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("3")).unwrap() => "move_to_workspace_3";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("4")).unwrap() => "move_to_workspace_4";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("5")).unwrap() => "move_to_workspace_5";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("6")).unwrap() => "move_to_workspace_6";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("7")).unwrap() => "move_to_workspace_7";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("8")).unwrap() => "move_to_workspace_8";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("9")).unwrap() => "move_to_workspace_9";
+        KeyPress::from_key_names(vec!("Alt", "Shift"), vec!("0")).unwrap() => "move_to_workspace_0"
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -39,6 +39,17 @@ pub fn init() {
             .expect("Unable to create default keypress")
             => "dmenu_lua_dofile";
 
+        /* Layout key bindings */
+        keypress!("Alt", "e") => "horizontal_vertical_switch";
+        keypress!("Alt", "v") => "split_vertical";
+        keypress!("Alt", "h") => "split_horizontal";
+        /* Focus key bindings */
+        keypress!("Alt", "left") => "focus_left";
+        keypress!("Alt", "right") => "focus_right";
+        keypress!("Alt", "up") => "focus_up";
+        keypress!("Alt", "down") => "focus_down";
+
+        /* Workspace switching key bindings */
         keypress!("Alt", "1") => "switch_workspace_1";
         keypress!("Alt", "2") => "switch_workspace_2";
         keypress!("Alt", "3") => "switch_workspace_3";

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -82,18 +82,11 @@ lazy_static! {
             quit_fn, keypress!("Alt", "Escape");
             terminal_fn, keypress!("Alt", "Return");
             dmenu_fn, keypress!("Alt", "d");
-            pointer_fn, keypress!("Alt", "p");
-            layout_test_fn, keypress!("Alt", "l")
+            pointer_fn, keypress!("Alt", "p")
         }
 
         RwLock::new(map)
     };
-}
-
-fn layout_test_fn() {
-    use layout::tree;
-    let mut tree = tree::try_lock_tree().unwrap();
-    tree.update_layout();
 }
 
 fn terminal_fn() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -86,11 +86,43 @@ lazy_static! {
             pointer_fn, keypress!("Alt", "p");
             horizontal_vertical_switch_fn, keypress!("Alt", "e");
             split_vertical, keypress!("Alt", "v");
-            split_horizontal, keypress!("Alt", "h")
+            split_horizontal, keypress!("Alt", "h");
+            move_left, keypress!("Alt", "left");
+            move_right, keypress!("Alt", "right");
+            move_up, keypress!("Alt", "up");
+            move_down, keypress!("Alt", "down")
         }
 
         RwLock::new(map)
     };
+}
+
+fn move_up() {
+    use layout::tree::Direction;
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.move_focus(Direction::Up)
+    }
+}
+
+fn move_down() {
+    use layout::tree::Direction;
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.move_focus(Direction::Down)
+    }
+}
+
+fn move_left() {
+    use layout::tree::Direction;
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.move_focus(Direction::Left)
+    }
+}
+
+fn move_right() {
+    use layout::tree::Direction;
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.move_focus(Direction::Right)
+    }
 }
 
 fn split_vertical() {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -86,8 +86,7 @@ lazy_static! {
             pointer_fn, keypress!("Alt", "p");
             horizontal_vertical_switch_fn, keypress!("Alt", "e");
             split_vertical, keypress!("Alt", "v");
-            split_horizontal, keypress!("Alt", "h");
-            debug_tree, keypress!("Alt", "q")
+            split_horizontal, keypress!("Alt", "h")
         }
 
         RwLock::new(map)
@@ -154,12 +153,6 @@ fn pointer_fn() {
 fn quit_fn() {
     info!("handler: Esc keypress!");
     ::rustwlc::terminate();
-}
-
-fn debug_tree() {
-    if let Ok(tree) = tree::try_lock_tree() {
-        error!("The tree: {:#?}", *tree);
-    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -10,7 +10,7 @@ use rustwlc::types::*; // Need * for bitflags...
 use super::commands;
 use registry::get_command;
 use super::layout::tree;
-use super::layout::container::Layout;
+use super::layout::container::{Layout, ContainerType};
 use super::lua;
 
 /// Register default keypresses to a map
@@ -111,7 +111,7 @@ fn split_horizontal() {
 fn horizontal_vertical_switch_fn() {
     if let Ok(mut tree) = tree::try_lock_tree() {
         tree.toggle_active_horizontal();
-        tree.update_layout();
+        tree.layout_active_of(ContainerType::Root);
     } else {
         error!("Could not grab tree")
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -49,6 +49,8 @@ pub fn init() {
         keypress!("Alt", "up") => "focus_up";
         keypress!("Alt", "down") => "focus_down";
 
+        keypress!("Alt", "q") => "remove_active";
+
         /* Workspace switching key bindings */
         keypress!("Alt", "1") => "switch_workspace_1";
         keypress!("Alt", "2") => "switch_workspace_2";

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -83,11 +83,28 @@ lazy_static! {
             terminal_fn, keypress!("Alt", "Return");
             dmenu_fn, keypress!("Alt", "d");
             pointer_fn, keypress!("Alt", "p");
-            horizontal_vertical_switch_fn, keypress!("Alt", "e")
+            horizontal_vertical_switch_fn, keypress!("Alt", "e");
+            split_vertical, keypress!("Alt", "v");
+            split_horizontal, keypress!("Alt", "h");
+            debug_tree, keypress!("Alt", "q")
         }
 
         RwLock::new(map)
     };
+}
+
+fn split_vertical() {
+    trace!("Splitting vertically");
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.active_split_vertical();
+    }
+}
+
+fn split_horizontal() {
+    trace!("Splitting horizontally");
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.active_split_horizontal();
+    }
 }
 
 fn horizontal_vertical_switch_fn() {
@@ -136,6 +153,12 @@ fn pointer_fn() {
 fn quit_fn() {
     info!("handler: Esc keypress!");
     ::rustwlc::terminate();
+}
+
+fn debug_tree() {
+    if let Ok(tree) = tree::try_lock_tree() {
+        error!("The tree: {:#?}", *tree);
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -92,7 +92,8 @@ lazy_static! {
 
 fn horizontal_vertical_switch_fn() {
     if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.toggle_active_horizontal()
+        tree.toggle_active_horizontal();
+        tree.update_layout();
     } else {
         error!("Could not grab tree")
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -90,8 +90,7 @@ lazy_static! {
             move_left, keypress!("Alt", "left");
             move_right, keypress!("Alt", "right");
             move_up, keypress!("Alt", "up");
-            move_down, keypress!("Alt", "down");
-            debug_tree, keypress!("Alt", "q")
+            move_down, keypress!("Alt", "down")
         }
 
         RwLock::new(map)
@@ -186,12 +185,6 @@ fn pointer_fn() {
 fn quit_fn() {
     info!("handler: Esc keypress!");
     ::rustwlc::terminate();
-}
-
-fn debug_tree() {
-    if let Ok(tree) = tree::try_lock_tree() {
-        error!("The tree: {:#?}", *tree);
-    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,183 +8,10 @@ use rustwlc::xkb::{Keysym, NameFlags};
 use rustwlc::types::*; // Need * for bitflags...
 
 use super::commands;
-use registry::get_command;
-use super::layout::tree;
-use super::layout::container::{Layout, ContainerType};
-use super::lua;
-
-/// Register default keypresses to a map
-macro_rules! register_defaults {
-    ( $map:expr; $($func:expr, $press:expr);+ ) => {
-        $(
-            let _ = $map.insert($press, Arc::new($func));
-            )+
-    }
-}
-
-/// Generate switch_workspace methods and register them in $map
-macro_rules! gen_switch_workspace {
-    ($map:expr; $($b:ident, $n:expr);+) => {
-        $(fn $b() {
-            trace!("Switching to workspace {}", $n);
-            if let Ok(mut tree)  = tree::try_lock_tree() {
-                tree.switch_to_workspace(&$n);
-            }
-        }
-          register_defaults!( $map; $b, keypress!("Alt", $n) );
-          )+
-    };
-}
-
-/// Generate move_container_to methods and register them in $map
-macro_rules! gen_move_to_workspace {
-    ($map:expr; $($b:ident, $n:expr);+) => {
-        $(fn $b() {
-            trace!("Moving active container to {}", $n);
-            if let Ok(mut tree) = tree::try_lock_tree() {
-                tree.send_active_to_workspace(&$n);
-            }
-        }
-          register_defaults!( $map; $b, KeyPress::from_key_names(vec!["Alt", "Shift"],
-                                                                vec![$n]).unwrap());
-        )+
-    };
-}
 
 lazy_static! {
-    static ref BINDINGS: RwLock<HashMap<KeyPress, KeyEvent>> = {
-        let mut map = HashMap::<KeyPress, KeyEvent>::new();
-
-        gen_move_to_workspace!(map;
-                               move_to_workspace_1, "1";
-                               move_to_workspace_2, "2";
-                               move_to_workspace_3, "3";
-                               move_to_workspace_4, "4";
-                               move_to_workspace_5, "5";
-                               move_to_workspace_6, "6";
-                               move_to_workspace_7, "7";
-                               move_to_workspace_8, "8";
-                               move_to_workspace_9, "9";
-                               move_to_workspace_0, "0");
-
-        gen_switch_workspace!(map; switch_workspace_1, "1";
-                              switch_workspace_2, "2";
-                              switch_workspace_3, "3";
-                              switch_workspace_4, "4";
-                              switch_workspace_5, "5";
-                              switch_workspace_6, "6";
-                              switch_workspace_7, "7";
-                              switch_workspace_8, "8";
-                              switch_workspace_9, "9";
-                              switch_workspace_0, "0");
-
-        register_defaults! {
-            map;
-            quit_fn, keypress!("Alt", "Escape");
-            terminal_fn, keypress!("Alt", "Return");
-            dmenu_fn, keypress!("Alt", "d");
-            pointer_fn, keypress!("Alt", "p");
-            horizontal_vertical_switch_fn, keypress!("Alt", "e");
-            split_vertical, keypress!("Alt", "v");
-            split_horizontal, keypress!("Alt", "h");
-            move_left, keypress!("Alt", "left");
-            move_right, keypress!("Alt", "right");
-            move_up, keypress!("Alt", "up");
-            move_down, keypress!("Alt", "down")
-        }
-
-        RwLock::new(map)
-    };
-}
-
-fn move_up() {
-    use layout::tree::Direction;
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.move_focus(Direction::Up)
-    }
-}
-
-fn move_down() {
-    use layout::tree::Direction;
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.move_focus(Direction::Down)
-    }
-}
-
-fn move_left() {
-    use layout::tree::Direction;
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.move_focus(Direction::Left)
-    }
-}
-
-fn move_right() {
-    use layout::tree::Direction;
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.move_focus(Direction::Right)
-    }
-}
-
-fn split_vertical() {
-    trace!("Splitting vertically");
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.toggle_active_layout(Layout::Vertical);
-    }
-}
-
-fn split_horizontal() {
-    trace!("Splitting horizontally");
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.toggle_active_layout(Layout::Horizontal);
-    }
-}
-
-fn horizontal_vertical_switch_fn() {
-    if let Ok(mut tree) = tree::try_lock_tree() {
-        tree.toggle_active_horizontal();
-        tree.layout_active_of(ContainerType::Root);
-    } else {
-        error!("Could not grab tree")
-    }
-}
-
-fn terminal_fn() {
-    use std::process::Command;
-    use std::env;
-
-    let term = env::var("WAYLAND_TERMINAL")
-        .unwrap_or("weston-terminal".to_string());
-
-    Command::new("sh")
-        .arg("-c")
-        .arg(term)
-        .spawn().expect("Error launching terminal");
-}
-
-fn dmenu_fn() {
-    use std::process::Command;
-    Command::new("sh")
-        .arg("-c")
-        .arg("dmenu_run")
-        .spawn().expect("Error launching terminal");
-}
-
-fn pointer_fn() {
-    use lua::LuaQuery;
-    let code = "if wm == nil then print('wm table does not exist')\n\
-                elseif wm.pointer == nil then print('wm.pointer table does not exist')\n\
-                else\n\
-                print('get_position is a func, preparing execution')
-                local x, y = wm.pointer.get_position()\n\
-                print('The cursor is at ' .. x .. ', ' .. y)\n\
-                end".to_string();
-    lua::send(LuaQuery::Execute(code))
-        .expect("Error telling Lua to get pointer coords");
-}
-
-fn quit_fn() {
-    info!("handler: Esc keypress!");
-    ::rustwlc::terminate();
+    static ref BINDINGS: RwLock<HashMap<KeyPress, KeyEvent>> =
+        RwLock::new(HashMap::new());
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -197,7 +24,7 @@ pub fn init() {
     macro_rules! insert_all {
         ( $($press:expr => $name:expr);+ ) => {
             register(vec![
-                $( ($press, get_command(&$name.to_string())
+                $( ($press, commands::get(&$name.to_string())
                   .expect("Unable to register default command!")) ),+
                 ]);
         }
@@ -207,10 +34,10 @@ pub fn init() {
         keypress!("Alt", "Escape") => "quit";
         keypress!("Alt", "Return") => "launch_terminal";
         keypress!("Alt", "d") => "launch_dmenu";
-        //keypress!("Alt", "l") => "dmenu_eval";
-        /*KeyPress::from_key_names(vec!["Alt", "Shift"], vec!["l"])
+        keypress!("Alt", "l") => "dmenu_eval";
+        KeyPress::from_key_names(vec!["Alt", "Shift"], vec!["l"])
             .expect("Unable to create default keypress")
-            => "dmenu_lua_dofile";*/
+            => "dmenu_lua_dofile";
 
         keypress!("Alt", "1") => "switch_workspace_1";
         keypress!("Alt", "2") => "switch_workspace_2";

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -90,7 +90,8 @@ lazy_static! {
             move_left, keypress!("Alt", "left");
             move_right, keypress!("Alt", "right");
             move_up, keypress!("Alt", "up");
-            move_down, keypress!("Alt", "down")
+            move_down, keypress!("Alt", "down");
+            debug_tree, keypress!("Alt", "q")
         }
 
         RwLock::new(map)
@@ -185,6 +186,12 @@ fn pointer_fn() {
 fn quit_fn() {
     info!("handler: Esc keypress!");
     ::rustwlc::terminate();
+}
+
+fn debug_tree() {
+    if let Ok(tree) = tree::try_lock_tree() {
+        error!("The tree: {:#?}", *tree);
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -252,6 +252,16 @@ impl Container {
         };
         return Ok(())
     }
+
+    pub fn set_layout(&mut self, new_layout: Layout) -> Result<(), String>{
+        match *self {
+            Container::Container { ref mut layout, .. } => *layout = new_layout,
+            ref other => return Err(
+                format!("Can only set the layout of a container, not {:?}",
+                        other))
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -84,8 +84,6 @@ pub enum Container {
     Container {
         /// How the container is layed out
         layout: Layout,
-        /// Whether the container is visible
-        visible: bool,
         /// If the container is focused
         focused: bool,
         /// If the container is floating
@@ -97,8 +95,6 @@ pub enum Container {
     View {
         /// The wlc handle to the view
         handle: WlcView,
-        /// Whether this view is visible
-        visible: bool,
         /// Whether this view is focused
         focused: bool,
         /// Whether this view is floating
@@ -128,7 +124,6 @@ impl Container {
     pub fn new_container(geometry: Geometry) -> Container {
         Container::Container {
             layout: Layout::Horizontal,
-            visible: false,
             focused: false,
             floating: false,
             geometry: geometry
@@ -139,7 +134,6 @@ impl Container {
     pub fn new_view(handle: WlcView) -> Container {
         Container::View {
             handle: handle,
-            visible: false,
             focused: false,
             floating: false
         }
@@ -147,11 +141,6 @@ impl Container {
 
     /// Sets the visibility of this container
     pub fn set_visibility(&mut self, visibility: bool) {
-        match *self {
-            Container::View { ref mut visible, .. } => *visible = visibility,
-            Container::Container { ref mut visible, .. } => *visible = visibility,
-            _ => {return},
-        }
         let mask = if visibility { 1 } else { 0 };
         if let Some(handle) = self.get_handle() {
             match handle {
@@ -160,16 +149,6 @@ impl Container {
                 },
                 _ => {},
             }
-        }
-    }
-
-    /// Gets the visibility flag of this container
-    #[allow(dead_code)]
-    pub fn get_visibility(&mut self) -> Option<bool> {
-        match *self {
-            Container::View { visible, .. } => Some(visible),
-            Container::Container { visible, .. } => Some(visible),
-            _ => None
         }
     }
 

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -209,12 +209,8 @@ impl Container {
                 size: size.clone()
             }),
             Container::Container { ref geometry, .. } => Some(geometry.clone()),
-            Container::View { ref handle, ..} => {
-                match handle.get_geometry() {
-                    Some(geometry) => Some(geometry.clone()),
-                    _ => None
-                }
-            },
+            Container::View { ref handle, ..} =>
+                handle.get_geometry().map(|geo| geo.clone()),
         }
     }
 

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -230,8 +230,10 @@ impl Container {
             }),
             Container::Container { ref geometry, .. } => Some(geometry.clone()),
             Container::View { ref handle, ..} => {
-                Some(handle.get_geometry().expect(
-                    "View did not have a geometry").clone())
+                match handle.get_geometry() {
+                    Some(geometry) => Some(geometry.clone()),
+                    _ => None
+                }
             },
         }
     }

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -334,4 +334,44 @@ mod tests {
         // NOTE Can't test view, because that will just segfault as well
         //let mut view = Container::new_view(WlcView::root());
     }
+
+    #[test]
+    fn layout_change_test() {
+        use rustwlc::*;
+        let root = Container::Root;
+        let output = Container::new_output(WlcView::root().as_output());
+        let workspace = Container::new_workspace("1".to_string(),
+                                                     Size { w: 500, h: 500 });
+        let mut container = Container::new_container(Geometry {
+            origin: Point { x: 0, y: 0},
+            size: Size { w: 0, h:0}
+        });
+        let view = Container::new_view(WlcView::root());
+
+        /* Container first, the only thing we can set the layout on */
+        let layout = match container {
+            Container::Container { ref layout, .. } => layout.clone(),
+            _ => panic!()
+        };
+        assert_eq!(layout, Layout::Horizontal);
+        let layouts = [Layout::Vertical, Layout::Horizontal,
+                       Layout::Tabbed, Layout::Stacked];
+        for new_layout in &layouts {
+            container.set_layout(*new_layout).ok();
+            let layout = match container {
+                Container::Container { ref layout, .. } => layout.clone(),
+                _ => panic!()
+            };
+            assert_eq!(layout, *new_layout);
+        }
+
+        for new_layout in &layouts {
+            for container in &mut [root.clone(), output.clone(),
+                                   workspace.clone(), view.clone()] {
+                let result = container.set_layout(*new_layout);
+                assert!(result.is_err());
+            }
+        }
+
+    }
 }

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -184,10 +184,11 @@ impl Container {
     #[allow(dead_code)]
     pub fn is_focused(&self) -> bool {
         match *self {
-            Container::Output { ref focused, .. } => focused.clone(),
-            Container::Workspace { ref focused, .. } => focused.clone(),
-            Container::View { ref focused, .. } => focused.clone(),
-            _ => false
+            Container::Root { .. } => false,
+            Container::Output { ref focused, .. } => *focused,
+            Container::Workspace { ref focused, .. } => *focused,
+            Container::Container { ref focused, .. } => *focused,
+            Container::View { ref focused, .. } =>*focused,
         }
     }
 
@@ -248,6 +249,7 @@ impl Container {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rustwlc::*;
 
     #[test]
     fn can_have_child() {
@@ -337,7 +339,6 @@ mod tests {
 
     #[test]
     fn layout_change_test() {
-        use rustwlc::*;
         let root = Container::Root;
         let output = Container::new_output(WlcView::root().as_output());
         let workspace = Container::new_workspace("1".to_string(),
@@ -372,6 +373,23 @@ mod tests {
                 assert!(result.is_err());
             }
         }
+    }
 
+    #[test]
+    fn is_focused_test() {
+        let root = Container::Root;
+        let output = Container::new_output(WlcView::root().as_output());
+        let workspace = Container::new_workspace("1".to_string(),
+                                                 Size { w: 500, h: 500 });
+        let container = Container::new_container(Geometry {
+            origin: Point { x: 0, y: 0},
+            size: Size { w: 0, h:0}
+        });
+        let view = Container::new_view(WlcView::root());
+        for container in &mut [root.clone(), output.clone(),
+                               container.clone(),
+                               workspace.clone(), view.clone()] {
+            assert_eq!(container.is_focused(), false);
+        }
     }
 }

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -216,6 +216,7 @@ impl Tree {
     }
 
     /// Attempts to get a descendant of the matching type
+    /// Looks down the left side of the tree first
     pub fn descendant_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {
         if let Some(container) = self.get(node_ix) {
@@ -225,7 +226,24 @@ impl Tree {
         }
         for child in self.children_of(node_ix) {
             if let Some(desc) = self.descendant_of_type(child, container_type) {
-                    return Some(desc)
+                return Some(desc)
+            }
+        }
+        return None
+    }
+
+    /// Attempts to get a descendant of the matching type.
+    /// Looks down the right side of the tree first
+    pub fn descendant_of_type_right(&self, node_ix: NodeIndex,
+                              container_type: ContainerType) -> Option<NodeIndex> {
+        if let Some(container) = self.get(node_ix) {
+            if container.get_type() == container_type {
+                return Some(node_ix)
+            }
+        }
+        for child in self.children_of(node_ix).iter().rev() {
+            if let Some(desc) = self.descendant_of_type(*child, container_type) {
+                return Some(desc)
             }
         }
         return None

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -30,6 +30,15 @@ impl Tree {
         self.root
     }
 
+    pub fn get_edge_weight_between(&self, parent_ix: NodeIndex, child_ix: NodeIndex)
+                            -> Option<&u32> {
+        if let Some(edge_ix) = self.graph.find_edge(parent_ix, child_ix) {
+            self.graph.edge_weight(edge_ix)
+        } else {
+            None
+        }
+    }
+
     /// Gets the edge value of the largest child of the node
     fn largest_child(&self, node: NodeIndex) -> (NodeIndex, u32) {
         use std::cmp::{Ord, Ordering};
@@ -54,7 +63,7 @@ impl Tree {
 
     /// Add an existing node (detached in the graph) to the tree.
     /// Note that floating nodes shouldn't exist for too long.
-    pub fn attach_child(&mut self, parent_ix: NodeIndex, child_ix: NodeIndex)
+    fn attach_child(&mut self, parent_ix: NodeIndex, child_ix: NodeIndex)
                      -> EdgeIndex {
         // Make sure the child doesn't have a parent
         if cfg!(debug_assertions) && self.has_parent(child_ix) {
@@ -72,6 +81,28 @@ impl Tree {
         }
         let (_ix, biggest_child) = self.largest_child(parent_ix);
         self.graph.update_edge(parent_ix, child_ix, biggest_child + 1)
+    }
+
+    /// Finds the index of the container at the child index's parent,
+    /// modifies it so that it's the given child number in the list.
+    pub fn correct_to(&mut self, child_ix: NodeIndex, mut child_pos: u32) {
+        let parent_ix = self.parent_of(child_ix)
+            .expect("Child had no parent");
+        let siblings = self.children_of(parent_ix);
+        if child_pos > siblings.len() as u32 {
+            child_pos = siblings.len() as u32;
+        }
+        let mut counter = child_pos + 1;
+        for sibling_ix in siblings {
+            let edge_weight = *self.get_edge_weight_between(parent_ix, sibling_ix)
+                .expect("Sibling had no edge weight");
+            if edge_weight < child_pos {
+                continue;
+            }
+            self.graph.update_edge(parent_ix, sibling_ix, counter);
+            counter += 1;
+        }
+        self.graph.update_edge(parent_ix, child_ix, child_pos);
     }
 
     /// Detaches a node from the tree (causing there to be two trees).

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -85,7 +85,7 @@ impl Tree {
 
     /// Finds the index of the container at the child index's parent,
     /// modifies it so that it's the given child number in the list.
-    pub fn correct_to(&mut self, child_ix: NodeIndex, mut child_pos: u32) {
+    pub fn set_child_pos(&mut self, child_ix: NodeIndex, mut child_pos: u32) {
         let parent_ix = self.parent_of(child_ix)
             .expect("Child had no parent");
         let siblings = self.children_of(parent_ix);

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -30,13 +30,11 @@ impl Tree {
         self.root
     }
 
-    pub fn get_edge_weight_between(&self, parent_ix: NodeIndex, child_ix: NodeIndex)
-                            -> Option<&u32> {
-        if let Some(edge_ix) = self.graph.find_edge(parent_ix, child_ix) {
-            self.graph.edge_weight(edge_ix)
-        } else {
-            None
-        }
+    /// Gets the weight of a possible edge between two notes
+    pub fn get_edge_weight_between(&self, parent_ix: NodeIndex,
+                                   child_ix: NodeIndex) -> Option<&u32> {
+        self.graph.find_edge(parent_ix, child_ix)
+            .and_then(|edge_ix| self.graph.edge_weight(edge_ix))
     }
 
     /// Gets the edge value of the largest child of the node

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -293,53 +293,37 @@ impl LayoutTree {
     /// We have to ensure that we aren't invalidating the active container
     /// when we remove a view or container.
     fn remove_view_or_container(&mut self, node_ix: NodeIndex) {
-        // NOTE make sure this remains valid
-        let mut parent_ix = self.tree.parent_of(node_ix)
-            .expect("Container we are removing had no parent");
-        if self.active_container.map(|c| c == node_ix).unwrap_or(false) {
-            // Update the active container if needed
-            if let Some(mut parent_index) = self.tree.ancestor_of_type(node_ix,
-                                                                   ContainerType::Container) {
-                if self.tree.is_last_ix(parent_index) {
-                    parent_index = node_ix;
-                }
-                if self.tree.is_last_ix(parent_ix) {
-                    parent_ix = node_ix;
-                }
-                // Remove the view from the tree
-                self.tree.remove(node_ix);
-                self.focus_on_next_container(parent_index);
+        // Only the root container has a non-container parent, and we can't remove that
+        if let Some(mut parent_ix) = self.tree.ancestor_of_type(node_ix,
+                                                                    ContainerType::Container) {
+            // If it'll move, fix that before that happens
+            if self.tree.is_last_ix(parent_ix) {
+                parent_ix = node_ix;
             }
-        } else {
-            // If the active container is the last index in the node array,
-            // its index will become this one.
-            if let Some(mut active_ix) = self.active_container {
-                if self.tree.is_last_ix(active_ix) {
-                    active_ix = node_ix;
+            // If the active container is *not* being removed,
+            // we must ensure that it won't be invalidated by the move
+            // (i.e: if it is the last index)
+            if self.active_container.map(|c| c != node_ix).unwrap_or(false) {
+                if self.tree.is_last_ix(self.active_container.unwrap()) {
+                    self.active_container = Some(node_ix);
                 }
-                if self.tree.is_last_ix(active_ix) {
-                    active_ix = node_ix;
-                }
-                if self.tree.is_last_ix(parent_ix) {
-                    parent_ix = node_ix;
-                }
-                self.tree.remove(node_ix);
-                self.active_container = Some(active_ix);
             }
+            self.tree.remove(node_ix);
+            self.focus_on_next_container(parent_ix);
+            // Remove parent container if it is a non-root container and has no other children
+            match self.tree[parent_ix].get_type() {
+                ContainerType::Container => {
+                    if self.is_root_container(parent_ix) {
+                        return;
+                    }
+                    if self.tree.children_of(parent_ix).len() == 0 {
+                        self.remove_view_or_container(parent_ix);
+                    }
+                }
+                _ => {},
+            }
+            self.update_active_of(ContainerType::Workspace);
         }
-        // Remove parent container if it is a non-root container and has no other children
-        match self.tree[parent_ix].get_type() {
-            ContainerType::Container => {
-                if self.is_root_container(parent_ix) {
-                    return;
-                }
-                if self.tree.children_of(parent_ix).len() == 0 {
-                    self.remove_view_or_container(parent_ix);
-                }
-            }
-            _ => {},
-        }
-        self.update_active_of(ContainerType::Workspace);
         self.validate();
     }
 

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -434,9 +434,17 @@ impl LayoutTree {
                         .expect("Container was not part of a workspace")
                 });
         }
-        // If this is reached, parent is workspace and there are no views in the tree
-        // so set the active container to be the root container
+        // If this is reached, parent is workspace
         let container_ix = self.tree.children_of(parent_ix)[0];
+        let root_c_children = self.tree.children_of(container_ix);
+        if root_c_children.len() > 0 {
+            self.active_container = Some(root_c_children[0]);
+            match self.tree[root_c_children[0]] {
+                Container::View { ref handle, .. } => handle.focus(),
+                _ => unreachable!()
+            };
+            return;
+        }
         trace!("Active container set to container {:?}", container_ix);
         self.active_container = Some(container_ix);
 

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -682,6 +682,36 @@ impl LayoutTree {
         }
     }
 
+    /// Gets the active container and toggles it based on the following rules:
+    /// * If horizontal, make it vertical
+    /// * else, make it horizontal
+    /// Updates the current active workspace's containers after toggling
+    pub fn toggle_active_horizontal(&mut self) {
+        if let Some(active_ix) = self.active_ix_of(ContainerType::Container) {
+            trace!("Toggling {:?} to be horizontal or vertical...", self.tree[active_ix]);
+            match self.tree[active_ix] {
+                Container::Container { ref mut layout, .. } => {
+                    match *layout {
+                        Layout::Horizontal => {
+                            trace!("Toggling to be vertical");
+                            *layout = Layout::Vertical
+                        }
+                        _ => {
+                            trace!("Toggling to be horizontal");
+                            *layout = Layout::Horizontal
+                        }
+                    }
+                },
+                _ => unreachable!()
+            }
+            if let Some(workspace_ix) = self.active_ix_of(ContainerType::Workspace) {
+                self.layout(workspace_ix);
+                return;
+            }
+        }
+        error!("No active container")
+    }
+
     /// Switch to the specified workspace
     pub fn switch_to_workspace(&mut self, name: &str) {
         if self.active_container.is_none() {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1233,6 +1233,24 @@ mod tests {
     }
 
     #[test]
+    fn add_output_test() {
+        let mut tree = basic_tree();
+        let new_output = WlcView::root().as_output();
+        tree.add_output(new_output);
+        let output_ix = tree.active_ix_of(ContainerType::Output).unwrap();
+        let handle = match tree.tree[output_ix].get_handle().unwrap() {
+            Handle::Output(output) => output,
+            _ => panic!()
+        };
+        assert_eq!(handle, new_output);
+        let workspace_ix = tree.tree.descendant_of_type(output_ix, ContainerType::Workspace).unwrap();
+        assert_eq!(tree.tree[workspace_ix].get_name().unwrap(), "1");
+        let active_ix = tree.active_container.unwrap();
+        assert_eq!(tree.tree.parent_of(active_ix).unwrap(), workspace_ix);
+        assert_eq!(tree.tree.children_of(active_ix).len(), 0);
+    }
+
+    #[test]
     /// Tests that we can remove the active container and have it properly reset
     fn basic_removal() {
         let mut tree = basic_tree();

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -112,12 +112,10 @@ impl LayoutTree {
         return None
     }
 
-    #[allow(dead_code)]
     fn active_of(&self, ctype: ContainerType) -> Option<&Container> {
         self.active_ix_of(ctype).and_then(|ix| self.tree.get(ix))
     }
 
-    #[allow(dead_code)]
     fn active_of_mut(&mut self, ctype: ContainerType) -> Option<&mut Container> {
         self.active_ix_of(ctype).and_then(move |ix| self.tree.get_mut(ix))
     }
@@ -493,7 +491,6 @@ impl LayoutTree {
 
     // Updates the tree's layout recursively starting from the root.
     // This is very expensive, since it traverses the entire tree.
-    #[allow(dead_code)]
     pub fn update_layout(&mut self) {
         let root_ix = self.tree.root_ix();
         self.layout(root_ix);

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1071,4 +1071,12 @@ mod tests {
         assert_eq!(new_active_container, *new_active_container_ix);
 
     }
+
+    #[test]
+    /// Ensure that calculate_scale is fair to all it's children
+    fn calculate_scale_test() {
+        assert_eq!(LayoutTree::calculate_scale(vec!(), 0.0), 0.0);
+        assert_eq!(LayoutTree::calculate_scale(vec!(5.0, 5.0, 5.0, 5.0, 5.0, 5.0), 0.0), 30.0);
+        assert_eq!(LayoutTree::calculate_scale(vec!(5.0, 5.0, 5.0, 5.0, -5.0, 0.0), 5.0), 22.0);
+    }
 }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1272,6 +1272,29 @@ mod tests {
     }
 
     #[test]
+    fn toggle_layout_test() {
+        let mut tree = basic_tree();
+        let root_container = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        tree.active_container = Some(root_container);
+        assert!(tree.is_root_container(root_container));
+        let layout = match tree.tree[root_container] {
+            Container::Container { ref layout, .. } => layout.clone(),
+            _ => panic!()
+        };
+        // default layout
+        assert_eq!(layout, Layout::Horizontal);
+        for new_layout in &[Layout::Vertical, Layout::Horizontal,
+                           Layout::Tabbed, Layout::Stacked] {
+            tree.toggle_active_layout(*new_layout);
+            let layout = match tree.tree[root_container] {
+                Container::Container { ref layout, .. } => layout.clone(),
+                _ => panic!()
+            };
+            assert_eq!(layout, *new_layout);
+        }
+    }
+
+    #[test]
     fn add_container_test() {
         let mut tree = basic_tree();
         let active_ix = tree.active_container.unwrap();

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -308,7 +308,7 @@ impl LayoutTree {
                     self.active_container = Some(node_ix);
                 }
             }
-            self.tree.remove(node_ix);
+            let container = self.tree.remove(node_ix);
             self.focus_on_next_container(parent_ix);
             // Remove parent container if it is a non-root container and has no other children
             match self.tree[parent_ix].get_type() {
@@ -322,6 +322,7 @@ impl LayoutTree {
                 }
                 _ => {},
             }
+            trace!("Removed container {:?}, index {:?}", container, node_ix);
             self.update_active_of(ContainerType::Workspace);
         }
         self.validate();

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1507,4 +1507,24 @@ mod tests {
         assert_eq!(old_ix, tree.active_container.unwrap());
         // Move left, be back on the very first one
     }
+
+    #[test]
+    fn switch_to_workspace_test() {
+        let mut tree = basic_tree();
+        let old_active = tree.active_container.clone();
+        let current_workspace_ix = tree.active_ix_of(ContainerType::Workspace).unwrap();
+        tree.active_container = None;
+        tree.switch_to_workspace("3");
+        // didn't move, because we have no active container
+        tree.active_container = old_active;
+        assert_eq!(tree.active_ix_of(ContainerType::Workspace).unwrap(), current_workspace_ix);
+        tree.switch_to_workspace("1");
+        // didn't move, because we aren't going anywhere different (same workspace)
+        assert_eq!(tree.active_ix_of(ContainerType::Workspace).unwrap(), current_workspace_ix);
+        tree.active_container = tree.active_ix_of(ContainerType::Output);
+        tree.switch_to_workspace("3");
+        // didn't move, because we aren't focused on something with a workspace
+        tree.active_container = old_active;
+        assert_eq!(tree.active_ix_of(ContainerType::Workspace).unwrap(), current_workspace_ix);
+    }
 }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1433,4 +1433,24 @@ mod tests {
             _ => unreachable!()
         }
     }
+
+    #[test]
+    fn move_focus_test() {
+        let mut tree = basic_tree();
+        let directions = [Direction::Up, Direction::Right,
+                          Direction::Down, Direction::Left];
+        let old_active_ix = tree.active_container.clone();
+        tree.active_container = None;
+        for direction in &directions {
+            // should do nothing when there is no active container
+            tree.move_focus(*direction);
+            assert_eq!(tree.active_container, None);
+        }
+        tree.active_container = old_active_ix;
+        for direction in &directions {
+            // should do nothing when there are no other views to move to
+            tree.move_focus(*direction);
+            assert_eq!(tree.active_container, old_active_ix);
+        }
+    }
 }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1254,6 +1254,31 @@ mod tests {
     }
 
     #[test]
+    fn add_container_test() {
+        let mut tree = basic_tree();
+        let active_ix = tree.active_container.unwrap();
+        let parent_ix = tree.tree.parent_of(active_ix).unwrap();
+        let old_edge_weight = *tree.tree.get_edge_weight_between(parent_ix, active_ix)
+            .unwrap();
+        // First and only child, so the edge weight is 1
+        assert_eq!(old_edge_weight, 1);
+        let geometry = Geometry {
+            origin: Point { x: 0, y: 0},
+            size: Size { w: 0, h: 0}
+        };
+        let new_container = Container::new_container(geometry);
+        tree.add_container(new_container, active_ix);
+        let new_active_ix = tree.active_container.unwrap();
+        // The view moved, since it was placed in the new container
+        assert!(active_ix != new_active_ix);
+        let new_container_ix = tree.tree.parent_of(new_active_ix).unwrap();
+        let new_edge_weight = *tree.tree.get_edge_weight_between(parent_ix, new_container_ix)
+            .unwrap();
+        assert_eq!(new_edge_weight, old_edge_weight);
+
+    }
+
+    #[test]
     fn non_root_container_auto_removal_test() {
         let mut tree = basic_tree();
         tree.switch_to_workspace("2");

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1307,7 +1307,13 @@ mod tests {
     #[test]
     fn move_to_workspace_test() {
         let mut tree = basic_tree();
+        /* Make sure sending to the current workspace does nothing */
         let old_view = tree.tree[tree.active_container.unwrap()].clone();
+        tree.send_active_to_workspace("1");
+        assert_eq!(old_view, tree.tree[tree.active_container.unwrap()]);
+        let old_view = tree.tree[tree.active_container.unwrap()].clone();
+        tree.send_active_to_workspace("2");
+        // Trying to send the root container does nothing
         tree.send_active_to_workspace("2");
         let active_ix = tree.active_container.unwrap();
         assert!(tree.is_root_container(active_ix));

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -323,7 +323,7 @@ impl LayoutTree {
                 _ => {},
             }
             trace!("Removed container {:?}, index {:?}", container, node_ix);
-            self.update_active_of(ContainerType::Workspace);
+            self.layout_active_of(ContainerType::Workspace);
         }
         self.validate();
     }
@@ -460,7 +460,7 @@ impl LayoutTree {
 
     // Updates the tree's layout recursively starting from the active container.
     // If the active container is a view, it starts at the parent container.
-    pub fn update_active_of(&mut self, c_type: ContainerType) {
+    pub fn layout_active_of(&mut self, c_type: ContainerType) {
         if let Some(container_ix) = self.active_ix_of(c_type) {
             match self.tree[container_ix].clone() {
                 Container::Root { .. } |
@@ -474,7 +474,7 @@ impl LayoutTree {
                 Container::View { .. } => {
                     warn!("Cannot simply update a view's geometry without {}",
                           "consulting container, updating it's parent");
-                    self.update_active_of(ContainerType::Container);
+                    self.layout_active_of(ContainerType::Container);
                 },
 
             }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -608,20 +608,6 @@ impl LayoutTree {
         }
     }
 
-    /// node_ix must be a container or a view
-    /// Though it should only be a container if stacked or tabbed? So just assume view for now
-    fn update_geometry(&self, node_ix: NodeIndex) {
-        match self.tree[node_ix] {
-            Container::View { .. } => {
-                unimplemented!()
-            },
-            Container::Container { .. } => {
-                unimplemented!()
-            },
-            _ => error!("Called update_geometry on a container that was not a view or a container")
-        }
-    }
-
     /// Calculates how much to scale on average for each value given.
     /// If the value is 0 (i.e the width or height of the container is 0),
     /// then it is calculated as max / children_values.len()

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -453,8 +453,6 @@ impl LayoutTree {
     /// will simply relocate the node to be destroyed and set it to be the active
     /// container.
     fn focus_on_next_container(&mut self, mut parent_ix: NodeIndex) {
-        warn!("node index: {:?}", parent_ix);
-        error!("tree: {:#?}", self);
         while self.tree.node_type(parent_ix)
             .expect("focus_next: unable to iterate") != ContainerType::Workspace {
             if let Some(view_ix) = self.tree.descendant_of_type(parent_ix,
@@ -798,8 +796,9 @@ impl LayoutTree {
                 },
                 _ => unreachable!()
             }
+        } else {
+            error!("No active container")
         }
-        error!("No active container")
     }
 
     /// Switch to the specified workspace

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -132,13 +132,13 @@ impl LayoutTree {
         return None
     }
 
-    /// Gets the WlcOutput the active container is located on
+    /// Gets the active output. This contains the WlcOutput
     #[allow(dead_code)]
     pub fn get_active_output(&self) -> Option<&Container> {
         self.active_of(ContainerType::Output)
     }
 
-    /// Gets the WlcOutput the active container is located on
+    /// Gets the active output. This contains the WlcOutput
     #[allow(dead_code)]
     pub fn get_active_output_mut(&mut self) -> Option<&mut Container> {
         self.active_of_mut(ContainerType::Output)
@@ -157,8 +157,6 @@ impl LayoutTree {
     }
 
     /// Gets the index of the workspace of this name
-    ///
-    /// TODO will search all outputs, probably should be more directed
     fn workspace_ix_by_name(&self, name: &str) -> Option<NodeIndex> {
         for output in self.tree.children_of(self.tree.root_ix()) {
             for workspace in self.tree.children_of(output) {
@@ -346,6 +344,8 @@ impl LayoutTree {
         self.update_active_of(ContainerType::Workspace);
     }
 
+    /// Determines if the container at the node index is the root.
+    /// Normally, this should only be true if the NodeIndex value is 1.
     fn is_root_container(&self, node_ix: NodeIndex) -> bool {
         self.tree[self.tree.parent_of(node_ix).unwrap_or(node_ix)].get_type() == ContainerType::Workspace
     }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -388,6 +388,7 @@ impl LayoutTree {
 
     // Updates the tree's layout recursively starting from the root.
     // This is very expensive, since it traverses the entire tree.
+    #[allow(dead_code)]
     pub fn update_layout(&mut self) {
         let root_ix = self.tree.root_ix();
         self.layout(root_ix);

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -450,14 +450,6 @@ impl LayoutTree {
         self.validate();
     }
 
-    // Updates the tree's layout recursively starting from the root.
-    // This is very expensive, since it traverses the entire tree.
-    pub fn update_layout(&mut self) {
-        let root_ix = self.tree.root_ix();
-        self.layout(root_ix);
-        self.validate();
-    }
-
     // Updates the tree's layout recursively starting from the active container.
     // If the active container is a view, it starts at the parent container.
     pub fn layout_active_of(&mut self, c_type: ContainerType) {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -528,7 +528,7 @@ impl LayoutTree {
 
             }
         } else {
-            error!("{:?} did not have a parent of type {:?}, doing nothing!",
+            warn!("{:?} did not have a parent of type {:?}, doing nothing!",
                    self, c_type);
         }
         self.validate();
@@ -961,7 +961,6 @@ impl LayoutTree {
     #[cfg(debug_assertions)]
     fn validate(&self) {
         use rustwlc::ViewType;
-        warn!("Validating the tree");
 
         // Recursive method to ensure child/parent nodes are connected
         fn validate_node_connections(this: &LayoutTree, parent_ix: NodeIndex) {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -861,6 +861,7 @@ impl LayoutTree {
     /// Validates the tree
     #[cfg(debug_assertions)]
     fn validate(&self) {
+        use rustwlc::ViewType;
         warn!("Validating the tree");
 
         // Recursive method to ensure child/parent nodes are connected
@@ -888,6 +889,10 @@ impl LayoutTree {
                     _ => panic!("Output container had no output")
                 };
             for view in output.get_views() {
+                // Ignore views we aren't supposed to tile
+                if view.get_type() != ViewType::empty() {
+                    continue;
+                }
                 if self.tree.descendant_with_handle(output_ix, &view).is_none() {
                     error!("View handle {:?} could not be found for {:?}",
                            view, output);

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1273,24 +1273,52 @@ mod tests {
 
     #[test]
     fn toggle_layout_test() {
-        let mut tree = basic_tree();
-        let root_container = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
-        tree.active_container = Some(root_container);
-        assert!(tree.is_root_container(root_container));
-        let layout = match tree.tree[root_container] {
-            Container::Container { ref layout, .. } => layout.clone(),
-            _ => panic!()
-        };
-        // default layout
-        assert_eq!(layout, Layout::Horizontal);
-        for new_layout in &[Layout::Vertical, Layout::Horizontal,
-                           Layout::Tabbed, Layout::Stacked] {
-            tree.toggle_active_layout(*new_layout);
+        {
+            let mut tree = basic_tree();
+            let root_container = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+            tree.active_container = Some(root_container);
+            assert!(tree.is_root_container(root_container));
             let layout = match tree.tree[root_container] {
                 Container::Container { ref layout, .. } => layout.clone(),
                 _ => panic!()
             };
-            assert_eq!(layout, *new_layout);
+            // default layout
+            assert_eq!(layout, Layout::Horizontal);
+            for new_layout in &[Layout::Vertical, Layout::Horizontal,
+                            Layout::Tabbed, Layout::Stacked] {
+                tree.toggle_active_layout(*new_layout);
+                let layout = match tree.tree[root_container] {
+                    Container::Container { ref layout, .. } => layout.clone(),
+                    _ => panic!()
+                };
+                assert_eq!(layout, *new_layout);
+            }
+        }
+        /* Now test wrapping the active container in a new container */
+        {
+            let mut tree = basic_tree();
+            let active_ix = tree.active_container.unwrap();
+            let active_container = tree.tree[active_ix].clone();
+            let old_parent = tree.tree[tree.tree.parent_of(active_ix).unwrap()]
+                .clone();
+            let old_layout = match old_parent {
+                Container::Container { ref layout, ..} => layout.clone(),
+                _ => panic!()
+            };
+            assert_eq!(old_layout, Layout::Horizontal);
+            tree.toggle_active_layout(Layout::Vertical);
+            // should still be focused on the previous container.
+            // though the active index might be different
+            let active_ix = tree.active_container.unwrap();
+            assert_eq!(active_container, tree.tree[active_ix]);
+            let new_parent = tree.tree[tree.tree.parent_of(active_ix).unwrap()]
+                .clone();
+            let new_layout = match new_parent {
+                Container::Container { ref layout, ..} => layout.clone(),
+                _ => panic!()
+            };
+            assert!(old_parent != new_parent);
+            assert_eq!(new_layout, Layout::Vertical);
         }
     }
 

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -305,12 +305,6 @@ impl LayoutTree {
             .expect("Node had no parent");
         if self.is_root_container(parent_ix) {
             if let Some(child_container) = self.tree.remove(child) {
-                match container {
-                    Container::Container { ref layout, .. } => {
-                        self.tree[parent_ix].set_layout(layout.clone()).ok()
-                    }
-                    _ => unreachable!()
-                };
                 let new_active_ix = self.tree.add_child(parent_ix, child_container);
                 self.active_container = Some(new_active_ix);
             }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -332,6 +332,7 @@ impl LayoutTree {
             }
             _ => {},
         }
+        self.update_active_of(ContainerType::Workspace);
     }
 
     fn is_root_container(&self, node_ix: NodeIndex) -> bool {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -435,7 +435,7 @@ impl LayoutTree {
     fn focus_on_next_container(&mut self, mut parent_ix: NodeIndex) {
         while self.tree.node_type(parent_ix)
             .expect("Node not part of the tree") != ContainerType::Workspace {
-            if let Some(view_ix) = self.tree.descendant_of_type(parent_ix,
+            if let Some(view_ix) = self.tree.descendant_of_type_right(parent_ix,
                                                            ContainerType::View) {
                 match self.tree[view_ix]
                                     .get_handle().expect("view had no handle") {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -227,46 +227,40 @@ impl LayoutTree {
             let parent_ix = self.tree.ancestor_of_type(view_ix,
                                                        ContainerType::Container)
                 .expect("View had no container parent");
+            let new_geometry: Geometry;
+            let num_siblings = cmp::max(1, self.tree.children_of(parent_ix).len() - 1)
+                as u32;
+            let parent_geometry = self.tree[parent_ix].get_geometry()
+                .expect("Parent container had no geometry");
             match self.tree[parent_ix] {
                 Container::Container { ref layout, .. } => {
                     match *layout {
                         Layout::Horizontal => {
-                            let num_siblings = cmp::max(1, self.tree.children_of(parent_ix).len() - 1)
-                                as u32;
-                            let parent_geometry = self.tree[parent_ix].get_geometry()
-                                .expect("Parent container had no geometry");
-                            let new_geometry = Geometry {
+                            new_geometry = Geometry {
                                 origin: parent_geometry.origin.clone(),
                                 size: Size {
                                     w: parent_geometry.size.w / num_siblings,
                                     h: parent_geometry.size.h
                                 }
                             };
-                            trace!("Setting view {:?} to geometry: {:?}",
-                                   self.tree[view_ix], parent_geometry);
-                            view.set_geometry(ResizeEdge::empty(), &new_geometry);
                         }
                         Layout::Vertical => {
-                            let num_siblings = cmp::max(1, self.tree.children_of(parent_ix).len() - 1)
-                                as u32;
-                            let parent_geometry = self.tree[parent_ix].get_geometry()
-                                .expect("Parent container had no geometry");
-                            let new_geometry = Geometry {
+                            new_geometry = Geometry {
                                 origin: parent_geometry.origin.clone(),
                                 size: Size {
                                     w: parent_geometry.size.w,
                                     h: parent_geometry.size.h / num_siblings
                                 }
                             };
-                            trace!("Setting view {:?} to geometry: {:?}",
-                                   self.tree[view_ix], parent_geometry);
-                            view.set_geometry(ResizeEdge::empty(), &new_geometry);
                         }
                         _ => unimplemented!()
                     }
                 },
                 _ => unreachable!()
             };
+            trace!("Setting view {:?} to geometry: {:?}",
+                   self.tree[view_ix], new_geometry);
+            view.set_geometry(ResizeEdge::empty(), &new_geometry);
         }
         self.validate();
     }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -195,6 +195,15 @@ impl LayoutTree {
         self.tree[self.tree.parent_of(node_ix).unwrap_or(node_ix)].get_type() == ContainerType::Workspace
     }
 
+    /// Determines if the active container is the root container
+    pub fn active_is_root(&self) -> bool {
+        if let Some(active_ix) = self.active_container {
+            self.is_root_container(active_ix)
+        } else {
+            false
+        }
+    }
+
     /// Make a new output container with the given WlcOutput.
     ///
     /// A new workspace is automatically added to the output, to ensure
@@ -985,8 +994,6 @@ impl LayoutTree {
     /// Validates the tree
     #[cfg(debug_assertions)]
     fn validate(&self) {
-        use rustwlc::ViewType;
-
         // Recursive method to ensure child/parent nodes are connected
         fn validate_node_connections(this: &LayoutTree, parent_ix: NodeIndex) {
             for child_ix in this.tree.children_of(parent_ix) {
@@ -1539,5 +1546,13 @@ mod tests {
         // didn't move, because we aren't focused on something with a workspace
         tree.active_container = old_active;
         assert_eq!(tree.active_ix_of(ContainerType::Workspace).unwrap(), current_workspace_ix);
+    }
+
+    #[test]
+    fn active_is_root_test() {
+        let mut tree = basic_tree();
+        assert_eq!(tree.active_is_root(), false);
+        tree.remove_active();
+        assert_eq!(tree.active_is_root(), true);
     }
 }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -425,8 +425,6 @@ impl LayoutTree {
         let mut children = self.tree.all_descendants_of(&container_ix);
         // add current container to the list as well
         children.push(container_ix);
-        // Sort by highest to lowest
-        children.sort_by(|a, b| b.cmp(a));
         for node_ix in children {
             trace!("Removing index {:?}: {:?}", node_ix, self.tree[node_ix]);
             match self.tree[node_ix] {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -61,6 +61,7 @@ pub type TreeResult = Result<MutexGuard<'static, LayoutTree>, TreeErr>;
 ///       - A Workspace can only have Containers as children
 ///   + Container
 ///       - A Container can only have other Containers or Views as children
+///       - All non-root containers need at least one child
 ///   + View
 ///       - A View must be associated with a WlcView
 ///       - A View cannot have any children

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1305,6 +1305,19 @@ mod tests {
     }
 
     #[test]
+    fn move_to_workspace_test() {
+        let mut tree = basic_tree();
+        let old_view = tree.tree[tree.active_container.unwrap()].clone();
+        tree.send_active_to_workspace("2");
+        let active_ix = tree.active_container.unwrap();
+        assert!(tree.is_root_container(active_ix));
+        tree.switch_to_workspace("2");
+        let active_ix = tree.active_container.unwrap();
+        // Switch to new workspace, should be focused on the old view
+        assert_eq!(old_view, tree.tree[active_ix]);
+    }
+
+    #[test]
     /// Ensure that calculate_scale is fair to all it's children
     fn calculate_scale_test() {
         assert_eq!(LayoutTree::calculate_scale(vec!(), 0.0), 0.0);

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -953,6 +953,8 @@ impl LayoutTree {
             self.tree.set_family_visible(curr_work_ix, true);
                 self.validate();
         }
+        let root_ix = self.tree.root_ix();
+        self.layout(root_ix);
     }
 
     /// Validates the tree

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -334,12 +334,14 @@ impl LayoutTree {
         self.tree[self.tree.parent_of(node_ix).unwrap_or(node_ix)].get_type() == ContainerType::Workspace
     }
 
-    /// Splits the active container vertically
-    pub fn active_split_vertical(&mut self) {
+    /// Changes the layout of the active container to the given layout.
+    /// If the active container is a view, a new container is added with the given
+    /// layout type.
+    pub fn toggle_active_layout(&mut self, new_layout: Layout) {
         if self.is_root_container(self.active_container.expect("No active container")) {
             match self.tree[self.active_container.unwrap()] {
                 Container::Container { ref mut layout, .. } =>
-                    *layout = Layout::Vertical,
+                    *layout = new_layout,
                 _ => unreachable!()
             }
             return;
@@ -349,27 +351,7 @@ impl LayoutTree {
             .get_geometry().expect("Active container had no geometry");
 
         let mut new_container = Container::new_container(active_geometry);
-        new_container.set_layout(Layout::Vertical).ok();
-        let active_ix = self.active_container.unwrap();
-        self.add_container(new_container, active_ix);
-        self.validate();
-    }
-
-    /// Splits the active container horizontally
-    pub fn active_split_horizontal(&mut self) {
-        if self.is_root_container(self.active_container.expect("No active container")) {
-            match self.tree[self.active_container.unwrap()] {
-                Container::Container { ref mut layout, .. } =>
-                    *layout = Layout::Horizontal,
-                _ => unreachable!()
-            }
-            return;
-        }
-        let active_geometry = self.get_active_container()
-            .expect("Could not get the active container")
-            .get_geometry().expect("Active container had no geometry");
-        let mut new_container = Container::new_container(active_geometry);
-        new_container.set_layout(Layout::Horizontal).ok();
+        new_container.set_layout(new_layout).ok();
         let active_ix = self.active_container.unwrap();
         self.add_container(new_container, active_ix);
         self.validate();

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -94,6 +94,9 @@ impl LayoutTree {
         info!("Active container was: {:?}", self.active_container);
         if let Some(node_ix) = self.tree.descendant_with_handle(self.tree.root_ix(), &handle) {
             self.active_container = Some(node_ix);
+            handle.focus();
+        } else {
+            warn!("Could not find handle {:?}", handle);
         }
         info!("Active container is now: {:?}", self.active_container);
     }
@@ -380,11 +383,11 @@ impl LayoutTree {
                             };
                             if maybe_new_index.is_some() &&
                                 maybe_new_index.unwrap() < siblings.len() {
-                                // There is a sibling to move to.
-                                let new_index = maybe_new_index.unwrap();
-                                let new_active = siblings[new_index];
-                                error!("yay switching focus to {:?}", new_active);
-                                self.active_container = Some(new_active);
+                                    // There is a sibling to move to.
+                                    let new_index = maybe_new_index.unwrap();
+                                    let new_active = siblings[new_index];
+                                    error!("yay switching focus to {:?}", new_active);
+                                    self.active_container = Some(new_active);
                             }
                         },
                         (Layout::Vertical, Direction::Left) |


### PR DESCRIPTION
This pull request adds the following features:
* Windows are auto-tiled
    - Can tile windows vertically or horizontally
    - Allows you to nest containers, allowing infinite flexibility in how you want to structure your windows
    - Modelled off i3's tiling, see [here](https://i3wm.org/docs/userguide.html#_tree) for more details
* Allows you to switch the focus of containers without the mouse
* Removed support to move and resize individual windows
* Adds the following commands (with default key bindings):
    - `horizontal_vertical_switch`, (alt+e): Switch the current container between horizontal and vertical layouts. If the current container is a view, this switches the parent's layout.
    - `split_vertical`, (alt+v): Takes the current container and adds it as the only child to a new vertically tiled container at the place where the active container was at originally. This is the primary way to make a new sub container with a vertical layout.
    - `split_horizontal`, (alt+h): Takes the current container and adds it as the only child to a new horizontally tiled container at the place where the active container was at originally. This is the primary way to make a new sub container with a horizontal layout.
    - `focus_{up,down,left,right}`, (alt+\<arrow key\>): Switch focus to the window to the {up,down,left,right} of the active container.
    - `move_to_workspace_{index}`, (alt+\<number\>): Move the active container to a different workspace.
    - `remove_active`, (alt+q): Remove the active container (the one currently focused).

This crosses out some features in #19