### PR TITLE
Way-Cooler no longer segfaults when closing with multiple windows

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -197,6 +197,9 @@ pub extern fn compositor_ready() {
 pub extern fn compositor_terminating() {
     info!("Compositor terminating!");
     lua::send(lua::LuaQuery::Terminate).ok();
+    if let Ok(mut tree) = tree::try_lock_tree() {
+        tree.destroy_tree();
+    }
 
 }
 


### PR DESCRIPTION
When multiple windows were open on Way-Cooler while it was being closed (either via a SIGINT signal or via the terminate command), it would mysteriously segfault. The issue was traced to the tree attempting to do operations on the views that were now invalidated by wlc. To remedy this, in the `compositor_terminating` callback the tree will now properly invalidate itself without attempting to close any views.