### PR TITLE
Added UUID to containers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustwlc 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,7 +46,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -72,7 +73,7 @@ name = "hlua"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "lua52-sys 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -100,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -114,7 +115,7 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -123,7 +124,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -133,7 +134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -151,6 +152,14 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "regex"
@@ -188,7 +197,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -202,7 +211,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -219,13 +228,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uuid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rustc-serialize = "0.3.*"
 json_macro = "0.1.*"
 unix_socket = "0.5.*"
 nix = "0.6.0"
+uuid = {version = "0.2", features = ["v4", "rustc-serialize"]}
 
 [dev-dependencies]
 dummy-rustwlc = "0.3.*"

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -1,5 +1,7 @@
 //! Container types
 
+use uuid::Uuid;
+
 use rustwlc::handle::{WlcView, WlcOutput};
 use rustwlc::{Geometry, Point, Size, ResizeEdge};
 
@@ -66,7 +68,9 @@ pub enum Container {
         /// Handle to the wlc
         handle: WlcOutput,
         /// Whether the output is focused
-        focused: bool
+        focused: bool,
+        /// UUID associated with container, client program can use container
+        id: Uuid,
     },
     /// Workspace
     Workspace {
@@ -79,6 +83,8 @@ pub enum Container {
         /// The size of the workspace on the screen.
         /// Might be different if there is e.g a bar present
         size: Size,
+        /// UUID associated with container, client program can use container
+        id: Uuid,
     },
     /// Container
     Container {
@@ -90,6 +96,8 @@ pub enum Container {
         floating: bool,
         /// The geometry of the container, relative to the parent container
         geometry: Geometry,
+        /// UUID associated with container, client program can use container
+        id: Uuid,
     },
     /// View or window
     View {
@@ -99,6 +107,8 @@ pub enum Container {
         focused: bool,
         /// Whether this view is floating
         floating: bool,
+        /// UUID associated with container, client program can use container
+        id: Uuid,
     }
 }
 
@@ -107,7 +117,8 @@ impl Container {
     pub fn new_output(handle: WlcOutput) -> Container {
         Container::Output {
             handle: handle,
-            focused: false
+            focused: false,
+            id: Uuid::new_v4()
         }
     }
 
@@ -116,7 +127,10 @@ impl Container {
     /// unless there is a bar or something.
     pub fn new_workspace(name: String, size: Size) -> Container {
         Container::Workspace {
-            name: name, focused: false, size: size
+            name: name,
+            focused: false,
+            size: size,
+            id: Uuid::new_v4()
         }
     }
 
@@ -126,7 +140,8 @@ impl Container {
             layout: Layout::Horizontal,
             focused: false,
             floating: false,
-            geometry: geometry
+            geometry: geometry,
+            id: Uuid::new_v4()
         }
     }
 
@@ -135,7 +150,8 @@ impl Container {
         Container::View {
             handle: handle,
             focused: false,
-            floating: false
+            floating: false,
+            id: Uuid::new_v4()
         }
     }
 
@@ -239,6 +255,16 @@ impl Container {
                         other))
         }
         Ok(())
+    }
+
+    pub fn get_id(&self) -> Option<Uuid> {
+        match *self {
+            Container::Root => None,
+            Container::Output { ref id, .. } | Container::Workspace { ref id, .. } |
+            Container::Container { ref id, .. } | Container::View { ref id, .. } => {
+                Some(*id)
+            }
+        }
     }
 }
 

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -144,6 +144,14 @@ impl Tree {
     /// the displaced node.
     pub fn remove(&mut self, node_ix: NodeIndex) -> Option<Container> {
         let id = self.graph[node_ix].get_id().unwrap();
+        let last_ix: NodeIndex<u32> = NodeIndex::new(self.graph.node_count() - 1);
+        if last_ix != node_ix {
+            // The container at last_ix will now have node_ix as its index
+            // Have to update the id map
+            let last_container = &self.graph[last_ix];
+            let last_id = last_container.get_id().expect("Could not get container id");
+            self.id_map.insert(last_id, node_ix);
+        }
         self.id_map.remove(&id);
         self.graph.remove_node(node_ix)
     }

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -2,9 +2,11 @@
 //! layout.
 
 use std::iter::Iterator;
+use std::collections::HashMap;
 
 use petgraph::EdgeDirection;
 use petgraph::graph::{Graph, NodeIndex, EdgeIndex};
+use uuid::Uuid;
 
 use rustwlc::WlcView;
 
@@ -14,6 +16,7 @@ use layout::{Container, ContainerType};
 #[derive(Debug)]
 pub struct Tree {
     graph: Graph<Container, u32>, // Directed graph
+    id_map: HashMap<Uuid, NodeIndex>,
     root: NodeIndex
 }
 
@@ -22,7 +25,10 @@ impl Tree {
     pub fn new() -> Tree {
         let mut graph = Graph::new();
         let root_ix = graph.add_node(Container::Root);
-        Tree { graph: graph, root: root_ix }
+        Tree { graph: graph,
+               id_map: HashMap::new(),
+               root: root_ix
+        }
     }
 
     /// Gets the index of the tree's root node
@@ -54,8 +60,10 @@ impl Tree {
     /// Adds a new child to a node at the index, returning the node index
     /// of the new child node.
     pub fn add_child(&mut self, parent_ix: NodeIndex, val: Container) -> NodeIndex {
+        let id = val.get_id().unwrap();
         let child_ix = self.graph.add_node(val);
         self.attach_child(parent_ix, child_ix);
+        self.id_map.insert(id, child_ix);
         child_ix
     }
 
@@ -135,6 +143,8 @@ impl Tree {
     /// with an endpoint in a, and including the edges with an endpoint in
     /// the displaced node.
     pub fn remove(&mut self, node_ix: NodeIndex) -> Option<Container> {
+        let id = self.graph[node_ix].get_id().unwrap();
+        self.id_map.remove(&id);
         self.graph.remove_node(node_ix)
     }
 

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1247,7 +1247,8 @@ mod tests {
         assert_eq!(tree.active_ix_of(ContainerType::Output), None);
         assert_eq!(tree.active_ix_of(ContainerType::Root), None);
         tree.set_active_container(WlcView::root());
-        assert_eq!(tree.get_active_container(), Some(&Container::new_view(WlcView::root())));
+        let view_ix = tree.tree.descendant_with_handle(tree.tree.root_ix(), &WlcView::root()).unwrap();
+        assert_eq!(tree.active_container, Some(view_ix));
         tree.unset_active_container();
         assert_eq!(tree.get_active_container(), None);
         assert_eq!(tree.active_container, None);
@@ -1453,18 +1454,19 @@ mod tests {
 
     #[test]
     fn move_to_workspace_test() {
+        // NOTE Need to test adding to workspace with stuff already in that workspace
         let mut tree = basic_tree();
         /* Make sure sending to the current workspace does nothing */
         let old_view = tree.tree[tree.active_container.unwrap()].clone();
         tree.send_active_to_workspace("1");
         assert_eq!(old_view, tree.tree[tree.active_container.unwrap()]);
-        let old_view = tree.tree[tree.active_container.unwrap()].clone();
-        tree.send_active_to_workspace("2");
+        //let old_view = tree.tree[tree.active_container.unwrap()].clone();
+        tree.send_active_to_workspace("3");
         // Trying to send the root container does nothing
-        tree.send_active_to_workspace("2");
+        tree.send_active_to_workspace("3");
         let active_ix = tree.active_container.unwrap();
         assert!(tree.is_root_container(active_ix));
-        tree.switch_to_workspace("2");
+        tree.switch_to_workspace("3");
         let active_ix = tree.active_container.unwrap();
         // Switch to new workspace, should be focused on the old view
         assert_eq!(old_view, tree.tree[active_ix]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ extern crate nix;
 
 extern crate petgraph;
 
+extern crate uuid;
+
 use std::env;
 
 use log::LogLevel;


### PR DESCRIPTION
* Added UUID dependency
* Containers now have a UUID, can be referred to by client programs and other parts of Way-Cooler outside of the layout tree.
* Container UUIDs are preserved even across moves and removes.
* Methods on the tree will generalize so that they perform operations on the container with that UUID instead of on the active container (though client programs will have a short hand to perform operations on the active container, e.g: `move_active_to(<uuid>)` as opposed to using the more general `move_container_to(<source uuid>, <destination uuid>)`