### PR TITLE
Tree cleanup

### DIFF
--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -80,7 +80,7 @@ impl Tree {
 
     /// Add an existing node (detached in the graph) to the tree.
     /// Note that floating nodes shouldn't exist for too long.
-    fn attach_child(&mut self, parent_ix: NodeIndex, child_ix: NodeIndex)
+    pub fn attach_child(&mut self, parent_ix: NodeIndex, child_ix: NodeIndex)
                      -> EdgeIndex {
         // Make sure the child doesn't have a parent
         if cfg!(debug_assertions) && self.has_parent(child_ix) {

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -124,7 +124,7 @@ impl Tree {
 
     /// Detaches a node from the tree (causing there to be two trees).
     /// This should only be done temporarily.
-    pub fn detach(&mut self, node_ix: NodeIndex) {
+    fn detach(&mut self, node_ix: NodeIndex) {
         if let Some(parent_ix) = self.parent_of(node_ix) {
             let edge = self.graph.find_edge(parent_ix, node_ix)
                 .expect("detatch: Node has parent but edge cannot be found!");

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -31,6 +31,17 @@ impl Tree {
         }
     }
 
+    /// Determines if the container at the node index is the root.
+    /// Normally, this should only be true if the NodeIndex value is 1.
+    pub fn is_root_container(&self, node_ix: NodeIndex) -> bool {
+        if let Some(parent_ix) = self.parent_of(node_ix) {
+            self.graph[parent_ix].get_type() == ContainerType::Workspace
+        } else {
+            false
+        }
+    }
+
+
     /// Gets the index of the tree's root node
     pub fn root_ix(&self) -> NodeIndex {
         self.root

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -167,6 +167,21 @@ impl Tree {
         self.graph.remove_node(node_ix)
     }
 
+    /// Determines if the container node can be removed because it is empty.
+    /// If it is a non-root container then it can never be removed.
+    pub fn can_remove_empty_parent(&self, container_ix: NodeIndex) -> bool {
+        if self.graph[container_ix].get_type() != ContainerType::Container
+        || self.is_root_container(container_ix) {
+            return false
+        }
+        if self.children_of(container_ix).len() == 0 {
+            true
+        } else {
+            false
+        }
+
+    }
+
     /// Moves a node between two indices
     pub fn move_node(&mut self, node_ix: NodeIndex, new_parent: NodeIndex) {
         self.detach(node_ix);

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -227,6 +227,19 @@ impl Tree {
         self.graph.node_weight(node_ix).map(Container::get_type)
     }
 
+    /// Gets the index of the workspace of this name
+    pub fn workspace_ix_by_name(&self, name: &str) -> Option<NodeIndex> {
+        for output in self.children_of(self.root_ix()) {
+            for workspace in self.children_of(output) {
+                if self.graph[workspace].get_name()
+                    .expect("workspace_by_name: bad tree structure") == name {
+                        return Some(workspace)
+                    }
+            }
+        }
+        return None
+    }
+
     /// Attempts to get an ancestor matching the matching type
     pub fn ancestor_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -1032,6 +1032,18 @@ impl LayoutTree {
                     trace!("The tree: {:#?}", self);
                     panic!()
                 }
+                for container_ix in self.tree.all_descendants_of(&workspace_ix) {
+                    match self.tree[container_ix] {
+                        Container::Container { .. } => {
+                            error!("Tree in invalid state. {:?} is an empty non-root container\n \
+                            {:#?}", container_ix, *self);
+                            assert!(! self.tree.can_remove_empty_parent(container_ix));
+                        },
+                        Container::View { .. } => {
+                        }
+                        _ => panic!("Non-view/container as descendant of a workspace!")
+                    }
+                }
             }
         }
     }

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -340,9 +340,8 @@ impl LayoutTree {
             .expect("Node had no parent");
         let old_weight = *self.tree.get_edge_weight_between(parent_ix, child_ix)
             .expect("parent and children were not connected");
-        self.tree.detach(child_ix);
         let new_container_ix = self.tree.add_child(parent_ix, container);
-        self.tree.attach_child(new_container_ix, child_ix);
+        self.tree.move_node(child_ix, new_container_ix);
         self.tree.set_child_pos(new_container_ix, old_weight);
         self.active_container = Some(new_container_ix);
         self.validate();
@@ -978,7 +977,7 @@ impl LayoutTree {
             }
 
             self.tree.set_family_visible(curr_work_ix, true);
-                self.validate();
+            self.validate();
         }
         let root_ix = self.tree.root_ix();
         self.layout(root_ix);

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -963,13 +963,16 @@ impl LayoutTree {
             self.tree.move_node(active_ix, next_work_root_ix);
 
             // Update the active container
-            if let Some(parent) = maybe_active_parent {
-                let ctype = self.tree.node_type(parent).unwrap_or(ContainerType::Root);
+            if let Some(parent_ix) = maybe_active_parent {
+                let ctype = self.tree.node_type(parent_ix).unwrap_or(ContainerType::Root);
                 if ctype == ContainerType::Container {
-                    self.focus_on_next_container(parent);
+                    self.focus_on_next_container(parent_ix);
                 } else {
                     trace!("Send to container invalidated a NodeIndex: {:?} to {:?}",
-                    parent, ctype);
+                    parent_ix, ctype);
+                }
+                if self.tree.can_remove_empty_parent(parent_ix) {
+                    self.remove_view_or_container(parent_ix);
                 }
             }
             else {
@@ -977,6 +980,7 @@ impl LayoutTree {
             }
 
             self.tree.set_family_visible(curr_work_ix, true);
+
             self.validate();
         }
         let root_ix = self.tree.root_ix();

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -210,7 +210,7 @@ impl LayoutTree {
     /// Determines if the active container is the root container
     pub fn active_is_root(&self) -> bool {
         if let Some(active_ix) = self.active_container {
-            self.is_root_container(active_ix)
+            self.tree.is_root_container(active_ix)
         } else {
             false
         }
@@ -301,7 +301,7 @@ impl LayoutTree {
             // Remove parent container if it is a non-root container and has no other children
             match self.tree[parent_ix].get_type() {
                 ContainerType::Container => {
-                    if self.is_root_container(parent_ix) {
+                    if self.tree.is_root_container(parent_ix) {
                         return;
                     }
                     if self.tree.children_of(parent_ix).len() == 0 {
@@ -534,7 +534,7 @@ impl LayoutTree {
         if self.active_container.is_none() {
             return;
         }
-        if self.is_root_container(self.active_container.expect("No active container")) {
+        if self.tree.is_root_container(self.active_container.expect("No active container")) {
             match self.tree[self.active_container.unwrap()] {
                 Container::Container { ref mut layout, .. } =>
                     *layout = new_layout,
@@ -1356,7 +1356,7 @@ mod tests {
             let mut tree = basic_tree();
             let root_container = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
             tree.active_container = Some(root_container);
-            assert!(tree.is_root_container(root_container));
+            assert!(tree.tree.is_root_container(root_container));
             let layout = match tree.tree[root_container] {
                 Container::Container { ref layout, .. } => layout.clone(),
                 _ => panic!()
@@ -1445,7 +1445,7 @@ mod tests {
         /* This should remove the other container,
         the count of the root container should be 0 */
         let active_ix = tree.active_container.unwrap();
-        assert!(tree.is_root_container(active_ix));
+        assert!(tree.tree.is_root_container(active_ix));
         let root_container = tree.tree.children_of(tree.active_ix_of(ContainerType::Workspace)
                                                    .expect("No active workspace"))[0];
         let num_children = tree.tree.children_of(root_container).len();
@@ -1465,7 +1465,7 @@ mod tests {
         // Trying to send the root container does nothing
         tree.send_active_to_workspace("3");
         let active_ix = tree.active_container.unwrap();
-        assert!(tree.is_root_container(active_ix));
+        assert!(tree.tree.is_root_container(active_ix));
         tree.switch_to_workspace("3");
         let active_ix = tree.active_container.unwrap();
         // Switch to new workspace, should be focused on the old view
@@ -1551,7 +1551,7 @@ mod tests {
         }
         // set to root container
         let root_container_ix = tree.tree.parent_of(old_active_ix.unwrap()).unwrap();
-        assert!(tree.is_root_container(root_container_ix));
+        assert!(tree.tree.is_root_container(root_container_ix));
         tree.active_container = Some(root_container_ix);
         for direction in &directions {
             tree.move_focus(*direction);

--- a/src/layout/tree.rs
+++ b/src/layout/tree.rs
@@ -288,10 +288,7 @@ impl LayoutTree {
             // Remove parent container if it is a non-root container and has no other children
             match self.tree[parent_ix].get_type() {
                 ContainerType::Container => {
-                    if self.tree.is_root_container(parent_ix) {
-                        return;
-                    }
-                    if self.tree.children_of(parent_ix).len() == 0 {
+                    if self.tree.can_remove_empty_parent(parent_ix) {
                         self.remove_view_or_container(parent_ix);
                     }
                 }


### PR DESCRIPTION
* Moved `is_root_container`, `workspace_ix_by_name`, and `can_remove_empty_container` to `graph_tree.rs` to reduce the size of `tree.rs`.
* `add_container` no longer inefficiently removes the nodes in order to move a child container into the newly constructed container. Instead, the edges are updated.
* Added checks for empty non-root container in `validate_tree`
* Fixed bug where moving container to another workspace would break the no empty non-root containers invariant.