### PR TITLE
Fixed focusing on views not in the tree

### DIFF
--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -149,7 +149,8 @@ impl Tree {
 
     /// Sets the view to be the new active container. Never fails
     pub fn set_active_view(&mut self, view: WlcView) -> CommandResult {
-        self.0.set_active_container(view);
+        self.0.set_active_container(view.clone());
+        view.focus();
         Ok(())
     }
 


### PR DESCRIPTION
This fixes not being able to focus on `dmenu` and the lua eval buffer