### PR TITLE
Added better tree error info propogated up

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -12,7 +12,7 @@ use std::thread;
 
 use compositor;
 use super::keys::{self, KeyPress, KeyEvent};
-use super::layout::{try_lock_tree, ContainerType};
+use super::layout::{try_lock_tree, ContainerType, TreeError};
 use super::lua::{self, LuaQuery};
 use super::background;
 
@@ -72,7 +72,12 @@ pub extern fn view_destroyed(view: WlcView) {
         tree.remove_view(view.clone()).and_then(|_| {
             tree.layout_active_of(ContainerType::Workspace)
         }).unwrap_or_else(|err| {
-            error!("Error in view_destroyed: {}", err);
+            match err {
+                TreeError::ViewNotFound(_) => {},
+                _ => {
+                    error!("Error in view_destroyed: {:?}", err);
+                }
+            }
         });
     } else {
         error!("Could not delete view {:?}", view);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -138,7 +138,7 @@ pub fn start_interactive_move(view: &WlcView, origin: &Point) -> bool {
         comp.view = Some(view.clone());
         if let Ok(mut tree) = try_lock_tree() {
             if let Err(err) = tree.set_active_view(view.clone()) {
-                error!("start_interactive_move error: {}", err);
+                error!("start_interactive_move error: {:?}", err);
                 return false
             } else {
                 return true

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -3,6 +3,8 @@
 
 use petgraph::graph::NodeIndex;
 
+use uuid::Uuid;
+
 use rustwlc::{WlcView, WlcOutput, Geometry, Point};
 
 use super::super::LayoutTree;
@@ -15,6 +17,21 @@ pub enum Direction {
     Down,
     Right,
     Left
+}
+
+#[derive(Clone, Debug)]
+pub enum TreeError {
+    /// A Node can nt be found in the tree with this Node Handle.
+    NodeNotFound(Uuid),
+    /// A WlcView handle could not be found in the tree.
+    ViewNotFound(WlcView),
+    /// A UUID was not associated with the this type of container.
+    UuidNotAssociatedWith(ContainerType),
+    /// UUID was associated with this container,
+    /// expected a container that had one of those other types.
+    UuuidWrongType(Container, Vec<ContainerType>),
+    /// There was no active/focused container.
+    NoActiveContainer,
 }
 
 impl LayoutTree {
@@ -162,14 +179,14 @@ impl LayoutTree {
     }
 
     //// Remove a view container from the tree
-    pub fn remove_view(&mut self, view: &WlcView) -> Result<(), String> {
+    pub fn remove_view(&mut self, view: &WlcView) -> Result<(), TreeError> {
         if let Some(view_ix) = self.tree.descendant_with_handle(self.tree.root_ix(), view) {
             self.remove_view_or_container(view_ix);
             self.validate();
             Ok(())
         } else {
             self.validate();
-            Err(format!("Could not find descendant with handle {:#?} to remove", view))
+            Err(TreeError::ViewNotFound(view.clone()))
         }
     }
 

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -21,7 +21,7 @@ pub enum Direction {
 
 #[derive(Clone, Debug)]
 pub enum TreeError {
-    /// A Node can nt be found in the tree with this Node Handle.
+    /// A Node can not be found in the tree with this Node Handle.
     NodeNotFound(Uuid),
     /// A WlcView handle could not be found in the tree.
     ViewNotFound(WlcView),

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -4,7 +4,7 @@ mod container;
 pub mod commands;
 
 pub use self::container::{Container, ContainerType, Handle, Layout};
-pub use self::layout_tree::tree::{Direction};
+pub use self::layout_tree::tree::{Direction, TreeError};
 use self::graph_tree::InnerTree;
 
 use petgraph::graph::NodeIndex;


### PR DESCRIPTION
Instead of just returning a simple error string, commands to the Tree will not return an error that has information about what actually went wrong so it can be dealt with at a higher level.