### PR TITLE
Updated use of rustwlc types to not use references

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -55,7 +55,8 @@ pub fn generate_solid_background(color: Color, output: WlcOutput) {
     let mut tmp = tempfile::tempfile().ok().expect("Unable to create a tempfile.");
 
     // Calculate how big the buffer needs to be from the output resolution
-    let resolution = output.get_resolution().clone();
+    let resolution = output.get_resolution()
+        .expect("Couldn't get output resolution");
     let (width, height) = (resolution.w as i32, resolution.h as i32);
     let size = (resolution.w * resolution.h) as i32;
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -48,7 +48,7 @@ pub extern fn output_resolution(output: WlcOutput,
     trace!("output_resolution: {:?} from  {:?} to {:?}",
            output, *old_size_ptr, *new_size_ptr);
     // Update the resolution of the output and its children
-    output.set_resolution(new_size_ptr.clone());
+    output.set_resolution(*new_size_ptr, 1);
     if let Ok(mut tree) = try_lock_tree() {
         tree.layout_active_of(ContainerType::Output)
             .expect("Could not layout active output");
@@ -126,7 +126,7 @@ pub extern fn keyboard_key(_view: WlcView, _time: u32, mods: &KeyboardModifiers,
         // TODO this function will throw an error in Rustwlc right now
         // let mut keys = keyboard::get_current_keys().into_iter()
         //      .map(|&k| Keysym::from(k)).collect();
-        let sym = keyboard::get_keysym_for_key(key, &KeyMod::empty());
+        let sym = keyboard::get_keysym_for_key(key, KeyMod::empty());
         let press = KeyPress::new(mods.mods, sym);
         if let Some(action) = keys::get(&press) {
             debug!("[key] Found an action for {}", press);

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -119,12 +119,13 @@ impl Tree {
             info!("Setting background: {}", view.get_title());
             view.send_to_back();
             let output = view.get_output();
-            let resolution = output.get_resolution().clone();
+            let resolution = output.get_resolution()
+                .expect("Couldn't get output resolution");
             let fullscreen = Geometry {
                 origin: Point { x: 0, y: 0 },
                 size: resolution
             };
-            view.set_geometry(ResizeEdge::empty(), &fullscreen);
+            view.set_geometry(ResizeEdge::empty(), fullscreen);
             return Ok(());
         }
         tree.add_view(view.clone());

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -218,7 +218,8 @@ impl Container {
             Container::Root { .. } => None,
             Container::Output { ref handle, .. } => Some(Geometry {
                 origin: Point { x: 0, y: 0 },
-                size: handle.get_resolution().clone(),
+                size: handle.get_resolution()
+                    .expect("Couldn't get output resolution")
             }),
             Container::Workspace { ref size, .. } => Some(Geometry {
                 origin: Point { x: 0, y: 0},
@@ -241,7 +242,7 @@ impl Container {
             Container::Workspace { ref mut size, .. } => *size = new_geometry.size,
             Container::Container { ref mut geometry, .. } => *geometry = new_geometry,
             Container::View { ref handle, .. } =>
-                handle.set_geometry(ResizeEdge::empty(), &new_geometry),
+                handle.set_geometry(ResizeEdge::empty(), new_geometry),
             _ => { return Err(format!("Could not set geometry on {:?}", self))}
         };
         return Ok(())

--- a/src/layout/layout_tree/layout.rs
+++ b/src/layout/layout_tree/layout.rs
@@ -22,7 +22,8 @@ impl LayoutTree {
                     Container::Output { ref handle, .. } => handle.clone(),
                     _ => unreachable!()
                 };
-                let size = handle.get_resolution().clone();
+                let size = handle.get_resolution()
+                    .expect("Couldn't get resolution");
                 let geometry = Geometry {
                     origin: Point { x: 0, y: 0 },
                     size: size
@@ -41,7 +42,8 @@ impl LayoutTree {
                 };
                 let output_geometry = Geometry {
                     origin: Point { x: 0, y: 0},
-                    size: handle.get_resolution().clone()
+                    size: handle.get_resolution()
+                        .expect("Couldn't get resolution")
                 };
                 trace!("layout: Laying out workspace, using size of the screen output {:?}", handle);
                 self.layout_helper(node_ix, output_geometry);
@@ -193,7 +195,7 @@ impl LayoutTree {
                 };
                 trace!("layout_helper: Laying out view {:?} with geometry constraints {:?}",
                        handle, geometry);
-                handle.set_geometry(ResizeEdge::empty(), &geometry);
+                handle.set_geometry(ResizeEdge::empty(), geometry);
             }
         }
         self.validate();
@@ -352,7 +354,7 @@ impl LayoutTree {
                 };
                 trace!("Setting view {:?} to geometry: {:?}",
                     self.tree[node_ix], new_geometry);
-                handle.set_geometry(ResizeEdge::empty(), &new_geometry);
+                handle.set_geometry(ResizeEdge::empty(), new_geometry);
             },
             _ => panic!("Can only normalize the view on a view or container")
         }


### PR DESCRIPTION
* `Geometry`, `Point`, `Size`, `WlcView` and `WlcOutput` are now copyable, so we no longer pass references around.