### PR TITLE
Fixes #56,only remove_active command close WlcView

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "way-cooler"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -1,7 +1,7 @@
 //! Commands from the user to manipulate the tree
 
 use super::try_lock_tree;
-use super::{ContainerType, Direction, Handle, Layout, TreeError};
+use super::{Container, ContainerType, Direction, Handle, Layout, TreeError};
 use super::Tree;
 
 use uuid::Uuid;
@@ -11,8 +11,13 @@ pub type CommandResult = Result<(), TreeError>;
 
 pub fn remove_active() {
     if let Ok(mut tree) = try_lock_tree() {
-        if let Some(view) = tree.0.remove_active() {
-            view.close()
+        if let Some(container) = tree.0.remove_active() {
+            match container {
+                Container::View { ref handle, .. } => {
+                    handle.close()
+                },
+                _ => {}
+            }
         }
         tree.0.layout_active_of(ContainerType::Root);
     }


### PR DESCRIPTION
We return the container now when we remove a node, so now it's up to the
caller whether or not the underlying WlcView should be closed