### PR TITLE
Switch workspace hotfix

### DIFF
--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -147,7 +147,16 @@ impl Tree {
     /// on views that have already been slated for removal from the wlc pool.
     /// Otherwise you leak a `WlcView`
     pub fn remove_view(&mut self, view: WlcView) -> CommandResult {
-        self.0.remove_view(&view).map(|_| ())
+        match self.0.remove_view(&view) {
+            Err(err)  => {
+                warn!("Remove view error: {:?}\n {:#?}", err, *self.0);
+                Err(err)
+            },
+            Ok(container) => {
+                trace!("Removed container {:?}", container);
+                Ok(())
+            }
+        }
     }
 
     #[allow(dead_code)]

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -197,14 +197,24 @@ impl Container {
     }
 
     /// Determines if the container is focused or not
-    #[allow(dead_code)]
     pub fn is_focused(&self) -> bool {
         match *self {
             Container::Root { .. } => false,
-            Container::Output { ref focused, .. } => *focused,
-            Container::Workspace { ref focused, .. } => *focused,
-            Container::Container { ref focused, .. } => *focused,
-            Container::View { ref focused, .. } =>*focused,
+            Container::Output { ref focused, .. } |
+            Container::Workspace { ref focused, .. } |
+            Container::Container { ref focused, .. } |
+            Container::View { ref focused, .. } => *focused,
+        }
+    }
+
+    /// Sets the focused value of the container
+    pub fn set_focused(&mut self, new_focused: bool) {
+        match *self {
+            Container::Root { .. } => {},
+            Container::Output { ref mut focused, .. } |
+            Container::Workspace { ref mut focused, .. } |
+            Container::Container { ref mut focused, .. } |
+            Container::View { ref mut focused, .. } => *focused = new_focused,
         }
     }
 

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -358,6 +358,7 @@ impl InnerTree {
 
     /// Sets the node and its children's visibility
     pub fn set_family_visible(&mut self, node_ix: NodeIndex, visible: bool) {
+        trace!("Setting {:?} to {}", node_ix, if visible {"visible"} else {"invisible"});
         self.get_mut(node_ix).map(|c| c.set_visibility(visible));
         for child in self.children_of(node_ix) {
             self.set_family_visible(child, visible);

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -441,6 +441,7 @@ mod tests {
                                                 Container::new_view(fake_view_1.clone()));
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
                                                 Container::new_view(fake_view_1.clone()));
+        tree[workspace_1_ix].set_focused(true);
         tree
     }
 

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -53,6 +53,7 @@ impl LayoutTree {
         }
     }
 
+    /// Sets the active container to be the given node.
     fn set_active_node(&mut self, node_ix: NodeIndex) {
         info!("Active container was {:?}", self.active_container);
         self.active_container = Some(node_ix);
@@ -550,6 +551,7 @@ impl LayoutTree {
                 let workspaces: Vec<NodeIndex> = self.tree.all_descendants_of(&self.tree.root_ix())
                     .into_iter().filter(|ix| self.tree[*ix].get_type() == ContainerType::Workspace)
                     .collect();
+                warn!("workspaces: {:?}", workspaces);
                 for workspace_ix in workspaces {
                     if self.tree[workspace_ix].is_focused() {
                         return Some(workspace_ix);
@@ -558,6 +560,7 @@ impl LayoutTree {
                 None
             });
         if maybe_active_ix.is_none() {
+            warn!("{:#?}", self);
             warn!("No active container, cannot switch");
             return;
         }
@@ -590,6 +593,7 @@ impl LayoutTree {
         self.tree.set_family_visible(workspace_ix, true);
         // Delete the old workspace if it has no views on it
         self.active_container = None;
+        self.tree[old_worksp_ix].set_focused(false);
         if self.tree.descendant_of_type(old_worksp_ix, ContainerType::View).is_none() {
             trace!("Removing workspace: {:?}", self.tree[old_worksp_ix].get_name()
                    .expect("Workspace had no name"));


### PR DESCRIPTION
It's going to be a while until we add paths to the Tree, but there was annoying bug I fixed with this hotfix.

Before, if you weren't focused on anything (like if had a menu open), then you couldn't switch workspaces because Way Cooler didn't know which workspace to tear down before drawing the new one. Now the workspace "remember" which was the last one that had an active container in it.

This will be removed when paths are added in #79