### PR TITLE
Remove unix_socket dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,6 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustwlc 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -309,15 +308,6 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "unix_socket"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ bitflags = "0.6"
 petgraph = "0.2"
 rustc-serialize = "0.3"
 json_macro = "0.1"
-unix_socket = "0.5"
 nix = "0.6"
 uuid = { version = "0.3", features = ["v4", "rustc-serialize"]}
 wayland-sys = { version = "^0.6.0", features = ["client", "dlopen"] }

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::fs;
 
 use nix::unistd::getuid;
-use unix_socket::UnixListener;
+use std::os::unix::net::UnixListener;
 
 mod channel;
 mod command;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,6 @@ extern crate hlua;
 extern crate rustc_serialize;
 #[macro_use]
 extern crate json_macro;
-extern crate unix_socket;
 
 extern crate nix;
 


### PR DESCRIPTION
This was merged into Rust in 1.10, directly from the nursery crate.