### PR TITLE
fixed capital typo in link to Contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Way Cooler was started by @Timidger and @SnirkImmington, but these fine people h
 And of course, thanks to the Rust community and the developers of [wlc].
 
 # Contributing
-Check out [Contributing](contributing.md) for more information.
+Check out [Contributing](Contributing.md) for more information.
 
 If you find bugs or have questions about the code, please [submit an issue] or [ping us on gitter][gitter].
 


### PR DESCRIPTION
The file `README.md` currently links in [this section](https://github.com/Immington-Industries/way-cooler#contributing)  to [this link](https://github.com/Immington-Industries/way-cooler/blob/master/contributing.md)  which doesn't exist. 

I.e. in the current `README.md` the link to `Contributing.md` is written with no capital letter, which is fixed by this pull request.