### PR TITLE
Added ability to move containers (Fixes #71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All keyboard shortcuts (except the command to exit Way Cooler) are configurable 
 - `Alt+v` Makes a new sub-container with a vertical layout
 - `Alt+h` Makes a new sub-container with a horizontal layout
 - `Alt+<arrow-key>` Switches focus to a window in that direction
+- `Alt+Shift+<arrow-key>` Moves active container in that direction
 - `Alt+<number-key>` Switches the current workspace
 - `Alt+shift+<number-key>` Moves the focused container to another workspace
 

--- a/config/init.lua
+++ b/config/init.lua
@@ -68,11 +68,16 @@ local keys = {
   key({ mod, "Shift" }, "l", "dmenu_lua_dofile"),
 
   -- Move focus
-  -- (if you're used to mod+arrow to switch workspaces you may wanna change them)
   key({ mod }, "left", "focus_left"),
   key({ mod }, "right", "focus_right"),
   key({ mod }, "up", "focus_up"),
   key({ mod }, "down", "focus_down"),
+
+  -- Move active container
+  key({ mod, "Shift" }, "left", "move_active_left"),
+  key({ mod, "Shift" }, "right", "move_active_right"),
+  key({ mod, "Shift" }, "up", "move_active_up"),
+  key({ mod, "Shift" }, "down", "move_active_down"),
 
   -- Split containers
   key({ mod }, "h", "split_horizontal"),

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -92,6 +92,10 @@ pub fn register_defaults() {
     register("focus_right", Arc::new(layout_cmds::focus_right));
     register("focus_up", Arc::new(layout_cmds::focus_up));
     register("focus_down", Arc::new(layout_cmds::focus_down));
+    register("move_active_left", Arc::new(layout_cmds::move_active_left));
+    register("move_active_right", Arc::new(layout_cmds::move_active_right));
+    register("move_active_up", Arc::new(layout_cmds::move_active_up));
+    register("move_active_down", Arc::new(layout_cmds::move_active_down));
     register("close_window", Arc::new(layout_cmds::remove_active))
 }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -33,7 +33,7 @@ pub fn tile_switch() {
         tree.0.toggle_active_horizontal();
         tree.layout_active_of(ContainerType::Workspace)
             .unwrap_or_else(|_| {
-                error!("Could not tile workspace");
+                warn!("Could not tile workspace");
             });
     }
 }
@@ -54,7 +54,7 @@ pub fn focus_left() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_focus(Direction::Left)
             .unwrap_or_else(|_| {
-                error!("Could not focus left");
+                warn!("Could not focus left");
             });
     }
 }
@@ -63,7 +63,7 @@ pub fn focus_right() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_focus(Direction::Right)
             .unwrap_or_else(|_| {
-                error!("Could not focus right");
+                warn!("Could not focus right");
             });
     }
 }
@@ -72,7 +72,7 @@ pub fn focus_up() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_focus(Direction::Up)
             .unwrap_or_else(|_| {
-                error!("Could not focus up");
+                warn!("Could not focus up");
             });
     }
 }
@@ -81,7 +81,7 @@ pub fn focus_down() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_focus(Direction::Down)
             .unwrap_or_else(|_| {
-                error!("Could not focus down");
+                warn!("Could not focus down");
             });
     }
 }
@@ -90,7 +90,7 @@ pub fn move_active_left() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Left)
             .unwrap_or_else(|_| {
-                error!("Could not focus right");
+                warn!("Could not focus right");
             })
     }
 }
@@ -108,7 +108,7 @@ pub fn move_active_up() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Up)
             .unwrap_or_else(|_| {
-                error!("Could not focus right");
+                warn!("Could not focus right");
             })
     }
 }
@@ -117,7 +117,7 @@ pub fn move_active_down() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Down)
             .unwrap_or_else(|_| {
-                error!("Could not focus right");
+                warn!("Could not focus right");
             })
     }
 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -204,7 +204,7 @@ impl Tree {
                     Ok(())
                 },
                 _ => {
-                    Err(TreeError::UuuidWrongType(self.0.tree[node_ix].clone(),
+                    Err(TreeError::UuidWrongType(self.0.tree[node_ix].get_id(),
                                                   vec!(ContainerType::View,
                                                        ContainerType::Container)))
                 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -133,13 +133,11 @@ impl Tree {
                         .or_else(|| self.0.get_active_container()
                                  .and_then(|container| Some(container.get_id())))
                         .ok_or(TreeError::NoActiveContainer));
-        self.0.move_active(uuid, direction);
+        try!(self.0.move_active(uuid, direction));
         // NOTE Make this not layout the active, but actually the node index's workspace.
-        self.layout_active_of(ContainerType::Workspace);
+        try!(self.layout_active_of(ContainerType::Workspace));
         Ok(())
     }
-    /*pub fn move_active(&mut self, direction: Direction) {
-    }*/
 
     /// Adds an Output to the tree. Never fails
     pub fn add_output(&mut self, output: WlcOutput) -> CommandResult {

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -133,7 +133,7 @@ impl Tree {
                         .or_else(|| self.0.get_active_container()
                                  .and_then(|container| Some(container.get_id())))
                         .ok_or(TreeError::NoActiveContainer));
-        try!(self.0.move_active(uuid, direction));
+        try!(self.0.move_container(uuid, direction));
         // NOTE Make this not layout the active, but actually the node index's workspace.
         try!(self.layout_active_of(ContainerType::Workspace));
         Ok(())

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -203,7 +203,7 @@ impl Container {
     /// Determines if the container is focused or not
     pub fn is_focused(&self) -> bool {
         match *self {
-            Container::Root { .. } => false,
+            Container::Root(_)  => false,
             Container::Output { ref focused, .. } |
             Container::Workspace { ref focused, .. } |
             Container::Container { ref focused, .. } |
@@ -214,7 +214,7 @@ impl Container {
     /// Sets the focused value of the container
     pub fn set_focused(&mut self, new_focused: bool) {
         match *self {
-            Container::Root { .. } => {},
+            Container::Root(_) => {},
             Container::Output { ref mut focused, .. } |
             Container::Workspace { ref mut focused, .. } |
             Container::Container { ref mut focused, .. } |

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -62,7 +62,7 @@ pub enum Layout {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Container {
     /// Root node of the container
-    Root,
+    Root(Uuid),
     /// Output
     Output {
         /// Handle to the wlc
@@ -113,6 +113,10 @@ pub enum Container {
 }
 
 impl Container {
+    /// Creates a new root container.
+    pub fn new_root() -> Container {
+        Container::Root(Uuid::new_v4())
+    }
     /// Creates a new output container with the given output
     pub fn new_output(handle: WlcOutput) -> Container {
         Container::Output {
@@ -171,7 +175,7 @@ impl Container {
     /// Gets the type of this container
     pub fn get_type(&self) -> ContainerType {
         match *self {
-            Container::Root => ContainerType::Root,
+            Container::Root(_) => ContainerType::Root,
             Container::Output { .. } => ContainerType::Output,
             Container::Workspace { .. } => ContainerType::Workspace,
             Container::Container { .. } => ContainerType::Container,
@@ -225,7 +229,7 @@ impl Container {
     /// origin is the coordinates relative to the parent container.
     pub fn get_geometry(&self) -> Option<Geometry> {
         match *self {
-            Container::Root { .. } => None,
+            Container::Root(_)  => None,
             Container::Output { ref handle, .. } => Some(Geometry {
                 origin: Point { x: 0, y: 0 },
                 size: handle.get_resolution()
@@ -268,12 +272,12 @@ impl Container {
         Ok(())
     }
 
-    pub fn get_id(&self) -> Option<Uuid> {
+    pub fn get_id(&self) -> Uuid {
         match *self {
-            Container::Root => None,
-            Container::Output { ref id, .. } | Container::Workspace { ref id, .. } |
-            Container::Container { ref id, .. } | Container::View { ref id, .. } => {
-                Some(*id)
+            Container::Root(id) | Container::Output { id, .. } |
+            Container::Workspace { id, .. } | Container::Container { id, .. } |
+            Container::View { id, .. } => {
+                id
             }
         }
     }

--- a/src/layout/container.rs
+++ b/src/layout/container.rs
@@ -340,7 +340,7 @@ mod tests {
             origin: Point { x: 1024, y: 2048},
             size: Size { w: 500, h: 700}
         };
-        let mut root = Container::Root;
+        let mut root = Container::new_root();
         assert!(root.get_geometry().is_none());
         assert!(root.set_geometry(test_geometry1.clone()).is_err());
 
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn layout_change_test() {
-        let root = Container::Root;
+        let root = Container::new_root();
         let output = Container::new_output(WlcView::root().as_output());
         let workspace = Container::new_workspace("1".to_string(),
                                                      Size { w: 500, h: 500 });
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn is_focused_test() {
-        let root = Container::Root;
+        let root = Container::new_root();
         let output = Container::new_output(WlcView::root().as_output());
         let workspace = Container::new_workspace("1".to_string(),
                                                  Size { w: 500, h: 500 });

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -24,7 +24,7 @@ impl InnerTree {
     /// Creates a new layout tree with a root node.
     pub fn new() -> InnerTree {
         let mut graph = Graph::new();
-        let root_ix = graph.add_node(Container::Root);
+        let root_ix = graph.add_node(Container::new_root());
         InnerTree { graph: graph,
                id_map: HashMap::new(),
                root: root_ix
@@ -71,7 +71,7 @@ impl InnerTree {
     /// Adds a new child to a node at the index, returning the node index
     /// of the new child node.
     pub fn add_child(&mut self, parent_ix: NodeIndex, val: Container) -> NodeIndex {
-        let id = val.get_id().unwrap();
+        let id = val.get_id();
         let child_ix = self.graph.add_node(val);
         self.attach_child(parent_ix, child_ix);
         self.id_map.insert(id, child_ix);
@@ -154,13 +154,13 @@ impl InnerTree {
     /// with an endpoint in a, and including the edges with an endpoint in
     /// the displaced node.
     pub fn remove(&mut self, node_ix: NodeIndex) -> Option<Container> {
-        let id = self.graph[node_ix].get_id().unwrap();
+        let id = self.graph[node_ix].get_id();
         let last_ix: NodeIndex<u32> = NodeIndex::new(self.graph.node_count() - 1);
         if last_ix != node_ix {
             // The container at last_ix will now have node_ix as its index
             // Have to update the id map
             let last_container = &self.graph[last_ix];
-            let last_id = last_container.get_id().expect("Could not get container id");
+            let last_id = last_container.get_id();
             self.id_map.insert(last_id, node_ix);
         }
         self.id_map.remove(&id);

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -12,6 +12,14 @@ use rustwlc::WlcView;
 
 use layout::{Container, ContainerType};
 
+#[derive(Clone, Copy, Debug)]
+pub enum GraphError {
+    /// These nodes were not siblings.
+    NotSiblingsError(NodeIndex, NodeIndex),
+    /// This node had no parent
+    NoParent(NodeIndex)
+}
+
 /// Layout tree implemented with petgraph.
 #[derive(Debug)]
 pub struct InnerTree {
@@ -125,11 +133,11 @@ impl InnerTree {
     /// Swaps the edge weight of the two child nodes. The nodes must
     /// be siblings of each other, otherwise this function will fail.
     pub fn swap_node_order(&mut self, child1_ix: NodeIndex,
-                           child2_ix: NodeIndex) -> Result<(), ()> {
-        let parent1_ix = try!(self.parent_of(child1_ix).ok_or(()));
-        let parent2_ix = try!(self.parent_of(child2_ix).ok_or(()));
+                           child2_ix: NodeIndex) -> Result<(), GraphError> {
+        let parent1_ix = try!(self.parent_of(child1_ix).ok_or(GraphError::NoParent(child1_ix)));
+        let parent2_ix = try!(self.parent_of(child2_ix).ok_or(GraphError::NoParent(child2_ix)));
         if parent2_ix != parent1_ix {
-            return Err(())
+            return Err(GraphError::NotSiblingsError(child1_ix, child2_ix))
         }
         let parent_ix = parent2_ix;
         let child1_weight = *self.get_edge_weight_between(parent_ix, child1_ix)

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -149,6 +149,9 @@ impl InnerTree {
         Ok(())
     }
 
+    /// Child's parent now becomes the new parent, with a certain weight.
+    ///
+    /// NOTE This function makes no guarantees on the uniqueness of the weight
     pub fn set_parent_of(&mut self, child_ix: NodeIndex, parent_ix: NodeIndex, weight: u32)
                          -> Result<(), GraphError> {
         let child_parent_ix = try!(self.parent_of(child_ix)

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -149,6 +149,17 @@ impl InnerTree {
         Ok(())
     }
 
+    pub fn set_parent_of(&mut self, child_ix: NodeIndex, parent_ix: NodeIndex, weight: u32)
+                         -> Result<(), GraphError> {
+        let child_parent_ix = try!(self.parent_of(child_ix)
+                                   .ok_or(GraphError::NoParent(child_ix)));
+        let parent_edge = self.graph.find_edge(child_parent_ix, child_ix)
+            .expect("No edge connection between parent and child");
+        self.graph.remove_edge(parent_edge);
+        self.graph.update_edge(parent_ix, child_ix, weight);
+        Ok(())
+    }
+
     /// Moves the node index at source so that it is a child of the target node.
     /// If the node could be moved, the new parent of the source node is returned
     /// (which is always the same as the target node).

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -163,15 +163,18 @@ impl InnerTree {
     /// Moves the node index at source so that it is a child of the target node.
     /// If the node was moved, the new parent of the source node is returned
     /// (which is always the same as the target node).
-    pub fn move_into(&mut self, source: NodeIndex, target: NodeIndex) -> Result<NodeIndex, GraphError> {
+    pub fn move_into(&mut self, source: NodeIndex, target: NodeIndex)
+                     -> Result<NodeIndex, GraphError> {
         let source_parent = try!(self.parent_of(source).ok_or(GraphError::NoParent(source)));
         let source_parent_edge = self.graph.find_edge(source_parent, source)
             .expect("Source node and it's parent were not linked");
         self.graph.remove_edge(source_parent_edge);
-        let highest_weight = self.graph.edges_directed(target, EdgeDirection::Outgoing).max()
-            .map(|(_ix, weight)| *weight).expect("Could not get highest weighted child of target node");
+        let highest_weight = self.graph.edges_directed(target, EdgeDirection::Outgoing)
+            .map(|(_ix, weight)| *weight).max()
+            .expect("Could not get highest weighted child of target node");
         self.graph.update_edge(target, source, highest_weight + 1);
         self.normalize_edge_weights(source_parent);
+        self.normalize_edge_weights(target);
         Ok(target)
     }
 

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -488,37 +488,34 @@ mod tests {
     fn test_id() {
         let mut tree = basic_tree();
         let root_ix = tree.root_ix();
-        {
-            // Root container should not have a UUID associated with it
-            let root = &tree[root_ix];
-            assert_eq!(root.get_id(), None);
-        }
         // This is the uuid of the view, we will invalidate it in the next block
         let view_id;
         {
-            let view_ix = tree.descendant_of_type(root_ix, ContainerType::View).unwrap();
+            let view_ix = tree.descendant_of_type(root_ix, ContainerType::View)
+                .expect("Had no descendant of type ContainerType View");
             let view_container = &tree[view_ix];
-            view_id = view_container.get_id().unwrap();
-            assert_eq!(*tree.id_map.get(&view_id).unwrap(), view_ix);
+            view_id = view_container.get_id();
+            assert_eq!(tree.id_map.get(&view_id), Some(&view_ix));
         }
         {
-            let view_ix = *tree.id_map.get(&view_id).unwrap();
+            let view_ix = *tree.id_map.get(&view_id)
+                .expect("View with a uuid did not exist");
             tree.remove(view_ix);
             assert_eq!(tree.id_map.get(&view_id), None);
         }
         let fake_view = WlcView::root();
         let root_container_ix = tree.descendant_of_type(root_ix, ContainerType::Container).unwrap();
         let container = Container::new_view(fake_view);
-        let container_uuid = container.get_id().unwrap();
+        let container_uuid = container.get_id();
         tree.add_child(root_container_ix, container.clone());
         let only_view = &tree[tree.descendant_of_type(root_ix, ContainerType::View).unwrap()];
         assert_eq!(*only_view, container);
-        assert_eq!(only_view.get_id(), Some(container_uuid));
+        assert_eq!(only_view.get_id(), container_uuid);
 
         // Generic test where we make sure all of them have the right ids in the map
         for container_ix in tree.all_descendants_of(&root_ix) {
             let container = &tree[container_ix];
-            let container_id = container.get_id().unwrap();
+            let container_id = container.get_id();
             assert_eq!(*tree.id_map.get(&container_id).unwrap(), container_ix);
         }
     }

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -161,7 +161,7 @@ impl InnerTree {
     }
 
     /// Moves the node index at source so that it is a child of the target node.
-    /// If the node could be moved, the new parent of the source node is returned
+    /// If the node was moved, the new parent of the source node is returned
     /// (which is always the same as the target node).
     pub fn move_into(&mut self, source: NodeIndex, target: NodeIndex) -> Result<NodeIndex, GraphError> {
         let source_parent = try!(self.parent_of(source).ok_or(GraphError::NoParent(source)));

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -122,6 +122,25 @@ impl InnerTree {
         self.graph.update_edge(parent_ix, child_ix, child_pos);
     }
 
+    /// Swaps the edge weight of the two child nodes. The nodes must
+    /// be siblings of each other, otherwise this function will fail.
+    pub fn swap_node_order(&mut self, child1_ix: NodeIndex,
+                           child2_ix: NodeIndex) -> Result<(), ()> {
+        let parent1_ix = try!(self.parent_of(child1_ix).ok_or(()));
+        let parent2_ix = try!(self.parent_of(child2_ix).ok_or(()));
+        if parent2_ix != parent1_ix {
+            return Err(())
+        }
+        let parent_ix = parent2_ix;
+        let child1_weight = *self.get_edge_weight_between(parent_ix, child1_ix)
+            .expect("Could not get weight between parent and child");
+        let child2_weight = *self.get_edge_weight_between(parent_ix, child2_ix)
+            .expect("Could not get weight between parent and child");
+        self.graph.update_edge(parent_ix, child1_ix, child2_weight);
+        self.graph.update_edge(parent_ix, child2_ix, child1_weight);
+        Ok(())
+    }
+
     /// Detaches a node from the tree (causing there to be two trees).
     /// This should only be done temporarily.
     fn detach(&mut self, node_ix: NodeIndex) {

--- a/src/layout/graph_tree.rs
+++ b/src/layout/graph_tree.rs
@@ -15,7 +15,7 @@ use layout::{Container, ContainerType};
 #[derive(Clone, Copy, Debug)]
 pub enum GraphError {
     /// These nodes were not siblings.
-    NotSiblingsError(NodeIndex, NodeIndex),
+    NotSiblings(NodeIndex, NodeIndex),
     /// This node had no parent
     NoParent(NodeIndex)
 }
@@ -147,7 +147,7 @@ impl InnerTree {
         let parent1_ix = try!(self.parent_of(child1_ix).ok_or(GraphError::NoParent(child1_ix)));
         let parent2_ix = try!(self.parent_of(child2_ix).ok_or(GraphError::NoParent(child2_ix)));
         if parent2_ix != parent1_ix {
-            return Err(GraphError::NotSiblingsError(child1_ix, child2_ix))
+            return Err(GraphError::NotSiblings(child1_ix, child2_ix))
         }
         let parent_ix = parent2_ix;
         let child1_weight = *self.get_edge_weight_between(parent_ix, child1_ix)

--- a/src/layout/layout_tree/layout.rs
+++ b/src/layout/layout_tree/layout.rs
@@ -207,7 +207,7 @@ impl LayoutTree {
     pub fn layout_active_of(&mut self, c_type: ContainerType) {
         if let Some(container_ix) = self.active_ix_of(c_type) {
             match self.tree[container_ix].clone() {
-                Container::Root { .. } |
+                Container::Root(_)  |
                 Container::Output { .. } |
                 Container::Workspace { .. } => {
                     self.layout(container_ix);

--- a/src/layout/layout_tree/mod.rs
+++ b/src/layout/layout_tree/mod.rs
@@ -1,2 +1,3 @@
 mod layout;
 pub mod tree;
+pub mod movement;

--- a/src/layout/layout_tree/movement.rs
+++ b/src/layout/layout_tree/movement.rs
@@ -307,4 +307,65 @@ mod tests {
             _ => panic!("Parent of active was not a vertical container")
         }
     }
+
+    #[test]
+    fn test_move_against_edges() {
+        let mut tree = basic_tree();
+        tree.switch_to_workspace("2");
+        // move the containers into one sub-vertical container, so we can test moving
+        // to the right and left outside this container
+        {
+            let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+            let children = tree.tree.children_of(active_parent);
+            assert_eq!(Some(children[0]), tree.active_container);
+            // make the first view have a vertical layout
+            tree.toggle_active_layout(Layout::Horizontal);
+            tree.active_container = Some(children[1]);
+            let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+            let children = tree.tree.children_of(active_parent);
+            let active_uuid = tree.get_active_container().unwrap().get_id();
+            // make sure the first container is the sub container, second is the view
+            assert_eq!(tree.tree[children[0]].get_type(), ContainerType::Container);
+            assert_eq!(tree.tree[children[1]].get_type(), ContainerType::View);
+            assert!(tree.move_container(active_uuid, Direction::Left).is_ok());
+        }
+        let active_ix = tree.active_container.unwrap();
+        let active_id = tree.tree[active_ix].get_id();
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(Some(children[1]), tree.active_container);
+        assert!(tree.move_container(active_id, Direction::Right).is_ok());
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        // Should only be the moved child here and the vertical container
+        assert_eq!(tree.tree[children[0]].get_type(), ContainerType::Container);
+        assert_eq!(tree.tree[children[1]].get_type(), ContainerType::View);
+
+        // move it back
+        assert!(tree.move_container(active_id, Direction::Left).is_ok());
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(tree.tree[children[0]].get_type(), ContainerType::View);
+        assert_eq!(tree.tree[children[1]].get_type(), ContainerType::View);
+
+
+        // Do it to the left now
+        println!("active: {:?}\ntree: {:?}", tree.active_container.unwrap(), tree);
+        assert!(tree.move_container(active_id, Direction::Left).is_ok());
+        println!("active: {:?}\ntree: {:?}", tree.active_container.unwrap(), tree);
+        assert!(tree.move_container(active_id, Direction::Left).is_ok());
+        println!("active: {:?}\ntree: {:?}", tree.active_container.unwrap(), tree);
+        assert!(false);
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+
+        // Should only be the moved child here and the vertical container
+        assert_eq!(tree.tree[children[0]].get_type(), ContainerType::View);
+        assert_eq!(tree.tree[children[1]].get_type(), ContainerType::Container);
+        assert!(tree.move_container(active_id, Direction::Right).is_ok());
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(tree.tree[children[0]].get_type(), ContainerType::View);
+        assert_eq!(tree.tree[children[1]].get_type(), ContainerType::View);
+    }
 }

--- a/src/layout/layout_tree/movement.rs
+++ b/src/layout/layout_tree/movement.rs
@@ -215,7 +215,7 @@ impl LayoutTree {
 #[cfg(test)]
 mod tests {
     use super::super::tree::tests::basic_tree;
-    use super::super::super::{Direction, Layout};
+    use super::super::super::{Direction, Container, ContainerType, Layout};
     use rustwlc::*;
 
     #[test]
@@ -245,5 +245,36 @@ mod tests {
         assert!(tree.move_container(active_uuid, Direction::Down).is_ok());
         let children = tree.tree.children_of(active_parent);
         assert_eq!(children[1], tree.active_container.unwrap());
+    }
+
+    #[test]
+    fn test_move_into_sub_container_dif_layout() {
+        let mut tree = basic_tree();
+        tree.switch_to_workspace("2");
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(Some(children[0]), tree.active_container);
+        // make the first view have a vertical layout
+        tree.toggle_active_layout(Layout::Vertical);
+        tree.active_container = Some(children[1]);
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        let active_uuid = tree.get_active_container().unwrap().get_id();
+        // make sure the first container is the sub container, second is the view
+        assert_eq!(tree.tree[children[0]].get_type(), ContainerType::Container);
+        assert_eq!(tree.tree[children[1]].get_type(), ContainerType::View);
+        println!("Active is {:?}, tree: \n {:#?}", tree.tree[tree.active_container.unwrap()],tree);
+        assert!(tree.move_container(active_uuid, Direction::Left).is_ok());
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        // we should all be in the same container now, in the vertical one
+        println!("Active is {:?}, tree: \n {:#?}", tree.tree[tree.active_container.unwrap()],tree);
+        assert_eq!(children.len(), 2);
+        match tree.tree[active_parent] {
+            Container::Container { ref layout, .. } => {
+                assert_eq!(*layout, Layout::Vertical);
+            }
+            _ => panic!("Parent of active was not a vertical container")
+        }
     }
 }

--- a/src/layout/layout_tree/movement.rs
+++ b/src/layout/layout_tree/movement.rs
@@ -1,0 +1,213 @@
+use uuid::Uuid;
+use petgraph::graph::NodeIndex;
+
+use super::super::{LayoutTree, Direction, TreeError};
+use super::super::graph_tree::{GraphError, ShiftDirection};
+use super::super::container::{Container, ContainerType, Handle, Layout};
+
+pub enum ContainerMovementError {
+    /// Attempted to move the node behind the UUID in the given direction,
+    /// which would cause it to leave its siblings.
+    MoveOutsideSiblings(Uuid, Direction),
+    /// There was a tree error, generally should abort operation and pass this
+    /// up back through the caller.
+    InternalTreeError(TreeError)
+}
+
+
+impl LayoutTree {
+    /// Returns the new parent of the active container if the move succeeds,
+    /// Otherwise it signals what error occurred in the tree.
+    pub fn move_recurse(&mut self, node_to_move: NodeIndex, move_ancestor: Option<NodeIndex>,
+                           direction: Direction) -> Result<NodeIndex, TreeError> {
+        match self.tree[node_to_move].get_type() {
+            ContainerType::View | ContainerType::Container => { /* continue */ },
+            _ => return Err(TreeError::UuidWrongType(self.tree[node_to_move].get_id(),
+                                                     vec!(ContainerType::View,
+                                                          ContainerType::Container)))
+        }
+        let parent_ix = try!(
+            move_ancestor.and_then(|node| {
+                self.tree.parent_of(node)
+            }).or(self.tree.parent_of(node_to_move))
+                .ok_or(TreeError::PetGraphError(GraphError::NoParent(node_to_move))));
+        match self.tree[parent_ix] {
+            Container::Container { layout, .. } =>  {
+                match (layout, direction) {
+                    (Layout::Horizontal, Direction::Left) |
+                    (Layout::Horizontal, Direction::Right) |
+                    (Layout::Vertical, Direction::Up) |
+                    (Layout::Vertical, Direction::Down) => {
+                        if let Some(ancestor_ix) = move_ancestor {
+                            match self.move_between_ancestors(node_to_move, ancestor_ix, direction) {
+                                Ok(new_parent_ix) => Ok(new_parent_ix),
+                                Err(ContainerMovementError::InternalTreeError(err)) => {
+                                    error!("Tree error moving between ancestors: {:?}", err);
+                                    Err(err)
+                                }
+                                Err(ContainerMovementError::MoveOutsideSiblings(node, dir)) => {
+                                    error!("Trying to move {:#?} in the {:?} direction somehow moved out of siblings",
+                                           node, dir);
+                                    panic!("Moving between ancestors failed in an unexpected way")
+                                }
+                            }
+                        } else { /* Moving within current parent container */
+                            match self.move_within_container(node_to_move, direction) {
+                                Ok(new_parent_ix) => {
+                                    Ok(new_parent_ix)
+                                },
+                                Err(ContainerMovementError::MoveOutsideSiblings(_,_)) => {
+                                    self.move_recurse(node_to_move, Some(parent_ix), direction)
+                                },
+                                Err(ContainerMovementError::InternalTreeError(err)) => {
+                                    Err(err)
+                                }
+                            }
+                        }
+                    },
+                    _ => { self.move_recurse(node_to_move, Some(parent_ix), direction) }
+                }
+            },
+            Container::Workspace { .. } => {
+                Err(TreeError::InvalidOperationOnRootContainer(self.tree[node_to_move].get_id()))
+            }
+            _ => unreachable!()
+        }
+    }
+
+    /// Attempt to move a container at the node index in the given direction.
+    ///
+    /// If the node would move outside of its current container by moving in that
+    /// direction, then ContainerMovementError::MoveOutsideSiblings is returned.
+    /// If the tree state is invalid, an appropriate wrapped up error is returned.
+    ///
+    /// If successful, the parent index of the node is returned.
+    fn move_within_container(&mut self, node_ix: NodeIndex, direction: Direction)
+                             -> Result<NodeIndex, ContainerMovementError> {
+        let parent_ix = try!(self.tree.parent_of(node_ix)
+                             .ok_or(ContainerMovementError::InternalTreeError(
+                                 TreeError::PetGraphError(GraphError::NoParent(node_ix)))));
+        let siblings_and_self = self.tree.children_of(parent_ix);
+        let cur_index = try!(siblings_and_self.iter().position(|node| {
+            *node == node_ix
+        }).ok_or(ContainerMovementError::InternalTreeError(
+            TreeError::NodeNotFound(self.tree[node_ix].get_id()))));
+        let maybe_new_index = match direction {
+            Direction::Right | Direction::Down => {
+                cur_index.checked_add(1)
+            }
+            Direction::Left  | Direction::Up => {
+                cur_index.checked_sub(1)
+            }
+        };
+        if maybe_new_index.is_some() && maybe_new_index.unwrap() < siblings_and_self.len() {
+            // There is a sibling to swap with
+            let swap_index = maybe_new_index.unwrap();
+            let swap_ix = siblings_and_self[swap_index];
+            match self.tree[swap_ix] {
+                Container::View { .. } => {
+                    try!(self.tree.swap_node_order(node_ix, swap_ix)
+                         .map_err(|err| ContainerMovementError::InternalTreeError(
+                             TreeError::PetGraphError(err))))
+                },
+                Container::Container { .. } => {
+                    try!(self.tree.move_into(node_ix, swap_ix)
+                         .map_err(|err| ContainerMovementError::InternalTreeError(
+                             TreeError::PetGraphError(err))));
+                    if let Some(handle) = self.tree[node_ix].get_handle() {
+                        match handle {
+                            Handle::View(view) => self.normalize_view(view),
+                            _ => unreachable!()
+                        }
+                    }
+                },
+                _ => return Err(ContainerMovementError::InternalTreeError(
+                    TreeError::UuidWrongType(self.tree[swap_ix].get_id(),
+                                             vec!(ContainerType::View, ContainerType::Container))))
+            };
+            Ok(self.tree.parent_of(node_ix)
+               .expect("Moved container had no new parent"))
+        } else {
+            // Tried to move outside the limit
+            Err(ContainerMovementError::MoveOutsideSiblings(self.tree[node_ix].get_id(), direction))
+        }
+    }
+
+    /// Moves the node in the direction, outside to ancestor siblings.
+    ///
+    /// Returns the new parent of the node on success
+    ///
+    /// This should only be called by the recursive function.
+    fn move_between_ancestors(&mut self,
+                              node_to_move: NodeIndex,
+                              move_ancestor: NodeIndex,
+                              direction: Direction)
+                                 -> Result<NodeIndex, ContainerMovementError> {
+        let cur_parent_ix = try!(self.tree.parent_of(move_ancestor)
+                                 .ok_or(ContainerMovementError::InternalTreeError(
+                                     TreeError::PetGraphError(
+                                         GraphError::NoParent(move_ancestor)))));
+        let siblings_and_self = self.tree.children_of(cur_parent_ix);
+        let cur_index = try!(siblings_and_self.iter().position(|node| {
+            *node == move_ancestor
+        }).ok_or(ContainerMovementError::InternalTreeError(
+            TreeError::NodeNotFound(self.tree[move_ancestor].get_id()))));
+        let next_ix = match direction {
+            Direction::Right | Direction::Down => {
+                let next_index = cur_index + 1;
+                if next_index as usize >= siblings_and_self.len() {
+                    return self.tree.add_to_end(node_to_move,
+                                                siblings_and_self[siblings_and_self.len() - 1],
+                                                ShiftDirection::Left)
+                        .and_then(|_| self.tree.parent_of(node_to_move)
+                             .ok_or(GraphError::NoParent(node_to_move)))
+                        .map_err(|err| ContainerMovementError::InternalTreeError(
+                            TreeError::PetGraphError(err)))
+                } else {
+                    siblings_and_self[next_index]
+                }
+            },
+            Direction::Left | Direction::Up => {
+                if let Some(next_index) = cur_index.checked_sub(1) {
+                    siblings_and_self[next_index]
+                } else {
+                    return self.tree.add_to_end(node_to_move,
+                                                siblings_and_self[0],
+                                                ShiftDirection::Right)
+                        .and_then(|_| self.tree.parent_of(node_to_move)
+                                  .ok_or(GraphError::NoParent(node_to_move)))
+                        .map_err(|err| ContainerMovementError::InternalTreeError(
+                            TreeError::PetGraphError(err)))
+                }
+            }
+        };
+        // Replace ancestor location with the node we are moving,
+        // shifts the others over
+        let parent_ix = try!(match self.tree[next_ix] {
+            Container::View { .. } => {
+                match direction {
+                    Direction::Right | Direction::Down => {
+                        self.tree.place_node_at(node_to_move, next_ix, ShiftDirection::Left)
+                    },
+                    Direction::Left | Direction::Up => {
+                        self.tree.place_node_at(node_to_move, next_ix, ShiftDirection::Right)
+                    }
+                }
+            },
+            Container::Container { .. } => {
+                self.tree.move_into(node_to_move, next_ix)
+            },
+            _ => unreachable!()
+        }.map_err(|err| ContainerMovementError::InternalTreeError(TreeError::PetGraphError(err))));
+        match self.tree[node_to_move] {
+            Container::View { handle, .. } => {
+                self.normalize_view(handle);
+                Ok(parent_ix)
+            },
+            _ => {
+                Err(ContainerMovementError::InternalTreeError(
+                    TreeError::UuidWrongType(self.tree[node_to_move].get_id(), vec!(ContainerType::View))))
+            },
+        }
+    }
+}

--- a/src/layout/layout_tree/movement.rs
+++ b/src/layout/layout_tree/movement.rs
@@ -350,12 +350,8 @@ mod tests {
 
 
         // Do it to the left now
-        println!("active: {:?}\ntree: {:?}", tree.active_container.unwrap(), tree);
         assert!(tree.move_container(active_id, Direction::Left).is_ok());
-        println!("active: {:?}\ntree: {:?}", tree.active_container.unwrap(), tree);
         assert!(tree.move_container(active_id, Direction::Left).is_ok());
-        println!("active: {:?}\ntree: {:?}", tree.active_container.unwrap(), tree);
-        assert!(false);
         let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
         let children = tree.tree.children_of(active_parent);
 

--- a/src/layout/layout_tree/movement.rs
+++ b/src/layout/layout_tree/movement.rs
@@ -211,3 +211,39 @@ impl LayoutTree {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::tree::tests::basic_tree;
+    use super::super::super::{Direction, Layout};
+    use rustwlc::*;
+
+    #[test]
+    fn test_basic_move() {
+        let mut tree = basic_tree();
+        tree.add_view(WlcView::root());
+        let active_uuid = tree.get_active_container().unwrap().get_id();
+        let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(children[1], tree.active_container.unwrap());
+        // These should do nothing, moving in wrong direction
+        assert!(tree.move_container(active_uuid, Direction::Up).is_err());
+        assert!(tree.move_container(active_uuid, Direction::Down).is_err());
+        assert!(tree.move_container(active_uuid, Direction::Right).is_err());
+        // test going left and right works
+        assert!(tree.move_container(active_uuid, Direction::Left).is_ok());
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(children[0], tree.active_container.unwrap());
+        assert!(tree.move_container(active_uuid, Direction::Right).is_ok());
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(children[1], tree.active_container.unwrap());
+        // test going up and down works
+        tree.toggle_active_horizontal();
+        assert!(tree.move_container(active_uuid, Direction::Up).is_ok());
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(children[0], tree.active_container.unwrap());
+        assert!(tree.move_container(active_uuid, Direction::Down).is_ok());
+        let children = tree.tree.children_of(active_parent);
+        assert_eq!(children[1], tree.active_container.unwrap());
+    }
+}

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -11,7 +11,7 @@ use super::super::LayoutTree;
 
 use super::super::container::{Container, Handle, ContainerType, Layout};
 
-use super::super::graph_tree::{GraphError, ShiftDirection};
+use super::super::graph_tree::GraphError;
 
 use super::super::commands::CommandResult;
 
@@ -41,15 +41,6 @@ pub enum TreeError {
     /// There was an error in the graph, an invariant of one of the
     /// functions were not held, so this might be an issue in the Tree.
     PetGraphError(GraphError)
-}
-
-pub enum ContainerMovementError {
-    /// Attempted to move the node behind the UUID in the given direction,
-    /// which would cause it to leave its siblings.
-    MoveOutsideSiblings(Uuid, Direction),
-    /// There was a tree error, generally should abort operation and pass this
-    /// up back through the caller.
-    InternalTreeError(TreeError)
 }
 
 impl LayoutTree {
@@ -355,6 +346,19 @@ impl LayoutTree {
         self.validate();
     }
 
+    /// Will attempt to move the container at the UUID in the given direction.
+    pub fn move_container(&mut self, uuid: Uuid, direction: Direction) -> CommandResult {
+        let node_ix = try!(self.tree.lookup_id(uuid).ok_or(TreeError::NodeNotFound(uuid)));
+        let old_parent_ix = try!(self.tree.parent_of(node_ix)
+                                 .ok_or(TreeError::PetGraphError(GraphError::NoParent(node_ix))));
+        try!(self.move_recurse(node_ix, None, direction));
+        if self.tree.can_remove_empty_parent(old_parent_ix) {
+            self.remove_container(old_parent_ix);
+        }
+        self.validate();
+        Ok(())
+    }
+
     /// Focus on the container relative to the active container.
     ///
     /// If Horizontal, left and right will move within siblings.
@@ -436,214 +440,6 @@ impl LayoutTree {
         let parent_ix = self.tree.parent_of(node_ix)
             .expect("Node had no parent");
         return self.move_focus_recurse(parent_ix, direction);
-    }
-
-    /// Will attempt to move the container at the UUID in the given direction.
-    pub fn move_container(&mut self, uuid: Uuid, direction: Direction) -> CommandResult {
-        let node_ix = try!(self.tree.lookup_id(uuid).ok_or(TreeError::NodeNotFound(uuid)));
-        let old_parent_ix = try!(self.tree.parent_of(node_ix)
-                                .ok_or(TreeError::PetGraphError(GraphError::NoParent(node_ix))));
-        try!(self.move_recurse(node_ix, None, direction));
-        if self.tree.can_remove_empty_parent(old_parent_ix) {
-            self.remove_container(old_parent_ix);
-        }
-        self.validate();
-        Ok(())
-    }
-
-    /// Returns the new parent of the active container if the move succeeds,
-    /// Otherwise it signals what error occurred in the tree.
-    fn move_recurse(&mut self, node_to_move: NodeIndex, move_ancestor: Option<NodeIndex>,
-                           direction: Direction) -> Result<NodeIndex, TreeError> {
-        match self.tree[node_to_move].get_type() {
-            ContainerType::View | ContainerType::Container => { /* continue */ },
-            _ => return Err(TreeError::UuidWrongType(self.tree[node_to_move].get_id(),
-                                                     vec!(ContainerType::View,
-                                                          ContainerType::Container)))
-        }
-        let parent_ix = try!(
-            move_ancestor.and_then(|node| {
-                self.tree.parent_of(node)
-            }).or(self.tree.parent_of(node_to_move))
-                .ok_or(TreeError::PetGraphError(GraphError::NoParent(node_to_move))));
-        match self.tree[parent_ix] {
-            Container::Container { layout, .. } =>  {
-                match (layout, direction) {
-                    (Layout::Horizontal, Direction::Left) |
-                    (Layout::Horizontal, Direction::Right) |
-                    (Layout::Vertical, Direction::Up) |
-                    (Layout::Vertical, Direction::Down) => {
-                        if let Some(ancestor_ix) = move_ancestor {
-                            match self.move_between_ancestors(node_to_move, ancestor_ix, direction) {
-                                Ok(new_parent_ix) => Ok(new_parent_ix),
-                                Err(ContainerMovementError::InternalTreeError(err)) => {
-                                    error!("Tree error moving between ancestors: {:?}", err);
-                                    Err(err)
-                                }
-                                Err(ContainerMovementError::MoveOutsideSiblings(node, dir)) => {
-                                    error!("Trying to move {:#?} in the {:?} direction somehow moved out of siblings",
-                                           node, dir);
-                                    panic!("Moving between ancestors failed in an unexpected way")
-                                }
-                            }
-                        } else { /* Moving within current parent container */
-                            match self.move_within_container(node_to_move, direction) {
-                                Ok(new_parent_ix) => {
-                                    Ok(new_parent_ix)
-                                },
-                                Err(ContainerMovementError::MoveOutsideSiblings(_,_)) => {
-                                    self.move_recurse(node_to_move, Some(parent_ix), direction)
-                                },
-                                Err(ContainerMovementError::InternalTreeError(err)) => {
-                                    Err(err)
-                                }
-                            }
-                        }
-                    },
-                    _ => { self.move_recurse(node_to_move, Some(parent_ix), direction) }
-                }
-            },
-            Container::Workspace { .. } => {
-                Err(TreeError::InvalidOperationOnRootContainer(self.tree[node_to_move].get_id()))
-            }
-            _ => unreachable!()
-        }
-    }
-
-    /// Attempt to move a container at the node index in the given direction.
-    ///
-    /// If the node would move outside of its current container by moving in that
-    /// direction, then ContainerMovementError::MoveOutsideSiblings is returned.
-    /// If the tree state is invalid, an appropriate wrapped up error is returned.
-    ///
-    /// If successful, the parent index of the node is returned.
-    fn move_within_container(&mut self, node_ix: NodeIndex, direction: Direction)
-                             -> Result<NodeIndex, ContainerMovementError> {
-        let parent_ix = try!(self.tree.parent_of(node_ix)
-                             .ok_or(ContainerMovementError::InternalTreeError(
-                                 TreeError::PetGraphError(GraphError::NoParent(node_ix)))));
-        let siblings_and_self = self.tree.children_of(parent_ix);
-        let cur_index = try!(siblings_and_self.iter().position(|node| {
-            *node == node_ix
-        }).ok_or(ContainerMovementError::InternalTreeError(
-            TreeError::NodeNotFound(self.tree[node_ix].get_id()))));
-        let maybe_new_index = match direction {
-            Direction::Right | Direction::Down => {
-                cur_index.checked_add(1)
-            }
-            Direction::Left  | Direction::Up => {
-                cur_index.checked_sub(1)
-            }
-        };
-        if maybe_new_index.is_some() && maybe_new_index.unwrap() < siblings_and_self.len() {
-            // There is a sibling to swap with
-            let swap_index = maybe_new_index.unwrap();
-            let swap_ix = siblings_and_self[swap_index];
-            match self.tree[swap_ix] {
-                Container::View { .. } => {
-                    try!(self.tree.swap_node_order(node_ix, swap_ix)
-                         .map_err(|err| ContainerMovementError::InternalTreeError(
-                             TreeError::PetGraphError(err))))
-                },
-                Container::Container { .. } => {
-                    try!(self.tree.move_into(node_ix, swap_ix)
-                         .map_err(|err| ContainerMovementError::InternalTreeError(
-                             TreeError::PetGraphError(err))));
-                    if let Some(handle) = self.tree[node_ix].get_handle() {
-                        match handle {
-                            Handle::View(view) => self.normalize_view(view),
-                            _ => unreachable!()
-                        }
-                    }
-                },
-                _ => return Err(ContainerMovementError::InternalTreeError(
-                    TreeError::UuidWrongType(self.tree[swap_ix].get_id(),
-                                             vec!(ContainerType::View, ContainerType::Container))))
-            };
-            Ok(self.tree.parent_of(node_ix)
-               .expect("Moved container had no new parent"))
-        } else {
-            // Tried to move outside the limit
-            Err(ContainerMovementError::MoveOutsideSiblings(self.tree[node_ix].get_id(), direction))
-        }
-    }
-
-    /// Moves the node in the direction, outside to ancestor siblings.
-    ///
-    /// Returns the new parent of the node on success
-    ///
-    /// This should only be called by the recursive function.
-    fn move_between_ancestors(&mut self,
-                              node_to_move: NodeIndex,
-                              move_ancestor: NodeIndex,
-                              direction: Direction)
-                                 -> Result<NodeIndex, ContainerMovementError> {
-        let cur_parent_ix = try!(self.tree.parent_of(move_ancestor)
-                                 .ok_or(ContainerMovementError::InternalTreeError(
-                                     TreeError::PetGraphError(
-                                         GraphError::NoParent(move_ancestor)))));
-        let siblings_and_self = self.tree.children_of(cur_parent_ix);
-        let cur_index = try!(siblings_and_self.iter().position(|node| {
-            *node == move_ancestor
-        }).ok_or(ContainerMovementError::InternalTreeError(
-            TreeError::NodeNotFound(self.tree[move_ancestor].get_id()))));
-        let next_ix = match direction {
-            Direction::Right | Direction::Down => {
-                let next_index = cur_index + 1;
-                if next_index as usize >= siblings_and_self.len() {
-                    return self.tree.add_to_end(node_to_move,
-                                                siblings_and_self[siblings_and_self.len() - 1],
-                                                ShiftDirection::Left)
-                        .and_then(|_| self.tree.parent_of(node_to_move)
-                             .ok_or(GraphError::NoParent(node_to_move)))
-                        .map_err(|err| ContainerMovementError::InternalTreeError(
-                            TreeError::PetGraphError(err)))
-                } else {
-                    siblings_and_self[next_index]
-                }
-            },
-            Direction::Left | Direction::Up => {
-                if let Some(next_index) = cur_index.checked_sub(1) {
-                    siblings_and_self[next_index]
-                } else {
-                    return self.tree.add_to_end(node_to_move,
-                                                siblings_and_self[0],
-                                                ShiftDirection::Right)
-                        .and_then(|_| self.tree.parent_of(node_to_move)
-                                  .ok_or(GraphError::NoParent(node_to_move)))
-                        .map_err(|err| ContainerMovementError::InternalTreeError(
-                            TreeError::PetGraphError(err)))
-                }
-            }
-        };
-        // Replace ancestor location with the node we are moving,
-        // shifts the others over
-        let parent_ix = try!(match self.tree[next_ix] {
-            Container::View { .. } => {
-                match direction {
-                    Direction::Right | Direction::Down => {
-                        self.tree.place_node_at(node_to_move, next_ix, ShiftDirection::Left)
-                    },
-                    Direction::Left | Direction::Up => {
-                        self.tree.place_node_at(node_to_move, next_ix, ShiftDirection::Right)
-                    }
-                }
-            },
-            Container::Container { .. } => {
-                self.tree.move_into(node_to_move, next_ix)
-            },
-            _ => unreachable!()
-        }.map_err(|err| ContainerMovementError::InternalTreeError(TreeError::PetGraphError(err))));
-        match self.tree[node_to_move] {
-            Container::View { handle, .. } => {
-                self.normalize_view(handle);
-                Ok(parent_ix)
-            },
-            _ => {
-                Err(ContainerMovementError::InternalTreeError(
-                    TreeError::UuidWrongType(self.tree[node_to_move].get_id(), vec!(ContainerType::View))))
-            },
-        }
     }
 
     /// Updates the current active container to be the next container or view
@@ -988,9 +784,7 @@ impl LayoutTree {
 
     #[cfg(not(debug_assertions))]
     pub fn validate(&self) {}
-
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -561,6 +561,9 @@ impl LayoutTree {
         }
     }
 
+    /// Moves the node in the direction, outside to ancestor siblings.
+    ///
+    /// This should only be called by the recursive function.
     fn move_between_ancestors(&mut self, node_ix: NodeIndex, direction: Direction)
                                  -> Result<NodeIndex, ContainerMovementError> {
         // TODO Abstract and pass in so we don't do duplicate work
@@ -606,12 +609,9 @@ impl LayoutTree {
                 }
             }
         };
-        // both this and the view branch down below look similar
-        // Can I combine them by doing a saturate_sub/add above?
-        // (with add saturating on the len)
-        // TODO Rewrite this to not use removal of nodes, but use graph_tree primitives (move_into)
+        // Replace ancestor location with the node we are moving,
+        // shifts the others over
         if next_index < 0 || next_index as usize >= siblings_and_self.len() {
-            error!("Edge case");
             if next_index < 0 {
                 next_index = 0;
             } else {

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -573,24 +573,31 @@ impl LayoutTree {
     /// Returns the new parent of the node on success
     ///
     /// This should only be called by the recursive function.
-    fn move_between_ancestors(&mut self, node_to_move: NodeIndex, move_ancestor: NodeIndex, direction: Direction)
+    fn move_between_ancestors(&mut self,
+                              node_to_move: NodeIndex,
+                              move_ancestor: NodeIndex,
+                              direction: Direction)
                                  -> Result<NodeIndex, ContainerMovementError> {
         let cur_parent_ix = try!(self.tree.parent_of(move_ancestor)
-            .ok_or(ContainerMovementError::InternalTreeError(TreeError::PetGraphError(GraphError::NoParent(move_ancestor)))));
+                                 .ok_or(ContainerMovementError::InternalTreeError(
+                                     TreeError::PetGraphError(
+                                         GraphError::NoParent(move_ancestor)))));
         let siblings_and_self = self.tree.children_of(cur_parent_ix);
         let cur_index = try!(siblings_and_self.iter().position(|node| {
             *node == move_ancestor
-        }).ok_or(ContainerMovementError::InternalTreeError(TreeError::NodeNotFound(self.tree[move_ancestor].get_id()))));
+        }).ok_or(ContainerMovementError::InternalTreeError(
+            TreeError::NodeNotFound(self.tree[move_ancestor].get_id()))));
         let next_ix = match direction {
             Direction::Right | Direction::Down => {
                 let next_index = cur_index + 1;
                 if next_index as usize >= siblings_and_self.len() {
-                    return self.tree.place_node_at(node_to_move,
-                                                   siblings_and_self[siblings_and_self.len() - 1],
-                                                   ShiftDirection::Left)
+                    return self.tree.add_to_end(node_to_move,
+                                                siblings_and_self[siblings_and_self.len() - 1],
+                                                ShiftDirection::Left)
                         .and_then(|_| self.tree.parent_of(node_to_move)
                              .ok_or(GraphError::NoParent(node_to_move)))
-                        .map_err(|err| ContainerMovementError::InternalTreeError(TreeError::PetGraphError(err)))
+                        .map_err(|err| ContainerMovementError::InternalTreeError(
+                            TreeError::PetGraphError(err)))
                 } else {
                     siblings_and_self[next_index]
                 }
@@ -599,10 +606,13 @@ impl LayoutTree {
                 if let Some(next_index) = cur_index.checked_sub(1) {
                     siblings_and_self[next_index]
                 } else {
-                    return self.tree.place_node_at(node_to_move, siblings_and_self[0], ShiftDirection::Right)
+                    return self.tree.add_to_end(node_to_move,
+                                                siblings_and_self[0],
+                                                ShiftDirection::Right)
                         .and_then(|_| self.tree.parent_of(node_to_move)
                                   .ok_or(GraphError::NoParent(node_to_move)))
-                        .map_err(|err| ContainerMovementError::InternalTreeError(TreeError::PetGraphError(err)))
+                        .map_err(|err| ContainerMovementError::InternalTreeError(
+                            TreeError::PetGraphError(err)))
                 }
             }
         };

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -27,9 +27,9 @@ pub enum TreeError {
     ViewNotFound(WlcView),
     /// A UUID was not associated with the this type of container.
     UuidNotAssociatedWith(ContainerType),
-    /// UUID was associated with this container,
+    /// UUID was associated with wrong container type,
     /// expected a container that had one of those other types.
-    UuuidWrongType(Container, Vec<ContainerType>),
+    UuidWrongType(Uuid, Vec<ContainerType>),
     /// There was no active/focused container.
     NoActiveContainer,
 }

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -617,15 +617,11 @@ impl LayoutTree {
             } else {
                 next_index = (siblings_and_self.len() + 1) as i32;
             }
-            let active_c = self.tree.remove(active_ix)
-                .expect("Could not remove active container");
-            // indices are invalidated, dropping to be safe
-            drop(siblings_and_self);
-            let new_active_ix = self.tree.add_child(parent_ix, active_c);
-            self.tree.set_child_pos(new_active_ix, next_index as u32);
-            self.active_container = Some(new_active_ix);
-            return Ok(self.tree.parent_of(new_active_ix)
-                .expect("Moved container had no new parent"))
+            self.tree.set_parent_of(active_ix, parent_ix, next_index as u32)
+                .expect("Could not set the new parent");
+            let new_parent = self.tree.parent_of(active_ix)
+                .expect("Could not get new parent");
+            return Ok(new_parent);
         }
         let mut next_ix = siblings_and_self[next_index as usize];
         match self.tree[next_ix] {

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -787,7 +787,7 @@ impl LayoutTree {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::super::super::LayoutTree;
     use super::super::super::container::*;
     use super::super::super::graph_tree::InnerTree;
@@ -803,7 +803,7 @@ mod tests {
     ///
     /// The active container is the only view in the first workspace
     #[allow(unused_variables)]
-    fn basic_tree() -> LayoutTree {
+    pub fn basic_tree() -> LayoutTree {
         let mut tree = InnerTree::new();
         let fake_view_1 = WlcView::root();
         let fake_output = fake_view_1.clone().as_output();

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -520,11 +520,13 @@ impl LayoutTree {
     fn move_within_container(&mut self, node_ix: NodeIndex, direction: Direction)
                              -> Result<NodeIndex, ContainerMovementError> {
         let parent_ix = try!(self.tree.parent_of(node_ix)
-            .ok_or(ContainerMovementError::InternalTreeError(TreeError::PetGraphError(GraphError::NoParent(node_ix)))));
+                             .ok_or(ContainerMovementError::InternalTreeError(
+                                 TreeError::PetGraphError(GraphError::NoParent(node_ix)))));
         let siblings_and_self = self.tree.children_of(parent_ix);
         let cur_index = try!(siblings_and_self.iter().position(|node| {
             *node == node_ix
-        }).ok_or(ContainerMovementError::InternalTreeError(TreeError::NodeNotFound(self.tree[node_ix].get_id()))));
+        }).ok_or(ContainerMovementError::InternalTreeError(
+            TreeError::NodeNotFound(self.tree[node_ix].get_id()))));
         let maybe_new_index = match direction {
             Direction::Right | Direction::Down => {
                 cur_index.checked_add(1)
@@ -540,11 +542,13 @@ impl LayoutTree {
             match self.tree[swap_ix] {
                 Container::View { .. } => {
                     try!(self.tree.swap_node_order(node_ix, swap_ix)
-                            .map_err(|err| ContainerMovementError::InternalTreeError(TreeError::PetGraphError(err))))
+                         .map_err(|err| ContainerMovementError::InternalTreeError(
+                             TreeError::PetGraphError(err))))
                 },
                 Container::Container { .. } => {
                     try!(self.tree.move_into(node_ix, swap_ix)
-                         .map_err(|err| ContainerMovementError::InternalTreeError(TreeError::PetGraphError(err))));
+                         .map_err(|err| ContainerMovementError::InternalTreeError(
+                             TreeError::PetGraphError(err))));
                     if let Some(handle) = self.tree[node_ix].get_handle() {
                         match handle {
                             Handle::View(view) => self.normalize_view(view),

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -431,17 +431,18 @@ impl LayoutTree {
 
     pub fn move_active(&mut self, uuid: Uuid, direction: Direction) -> CommandResult {
         let node_ix = try!(self.tree.lookup_id(uuid).ok_or(TreeError::NodeNotFound(uuid)));
-        let new_parent_ix = try!(self.move_active_recurse(node_ix, direction));
+        let _new_parent_ix = try!(self.move_active_recurse(node_ix, direction));
         self.validate();
         Ok(())
     }
 
-    /// Returns the new parent of the active container if the move succeeds
+    /// Returns the new parent of the active container if the move succeeds,
+    /// Otherwise it signals what error occurred in the tree.
     fn move_active_recurse(&mut self, node_ix: NodeIndex,
                            direction: Direction) -> Result<NodeIndex, TreeError> {
         match self.tree[node_ix].get_type() {
             ContainerType::View | ContainerType::Container => { /* continue */ },
-            c_type => return Err(TreeError::UuidWrongType(self.tree[node_ix].get_id(),
+            _ => return Err(TreeError::UuidWrongType(self.tree[node_ix].get_id(),
                                                           vec!(ContainerType::View,
                                                                ContainerType::Container)))
         }
@@ -1114,11 +1115,12 @@ mod tests {
         tree.add_view(WlcView::root());
         assert_eq!(tree.tree.children_of(parent_container).len(), 2);
         assert!(! (old_active_view == tree.active_ix_of(ContainerType::View).unwrap()));
-        tree.remove_view(&WlcView::root());
+        tree.remove_view(&WlcView::root())
+            .expect("Could not remove view");
         assert_eq!(tree.active_ix_of(ContainerType::View).unwrap(), old_active_view);
         assert_eq!(tree.tree.children_of(parent_container).len(), 1);
         for _ in 1..2 {
-            tree.remove_view(&WlcView::root());
+            tree.remove_view(&WlcView::root()).expect("Could not remove view");
         }
     }
 

--- a/src/layout/layout_tree/tree.rs
+++ b/src/layout/layout_tree/tree.rs
@@ -429,7 +429,8 @@ impl LayoutTree {
         return self.move_focus_recurse(parent_ix, direction);
     }
 
-    pub fn move_active(&mut self, uuid: Uuid, direction: Direction) -> CommandResult {
+    /// Will attempt to move the container at the UUID in the given direction.
+    pub fn move_container(&mut self, uuid: Uuid, direction: Direction) -> CommandResult {
         let node_ix = try!(self.tree.lookup_id(uuid).ok_or(TreeError::NodeNotFound(uuid)));
         let _new_parent_ix = try!(self.move_active_recurse(node_ix, direction));
         self.validate();


### PR DESCRIPTION
* A new keybinding to move the active view: `Alt+Shift+<Arrow-Key>` to move in a desired direction.
* Split up the code a bit more, all of the movement code is in its own module.
* Tiny cleanups here and there where we can have better error propagation, more tracing, or easier to read code.