### PR TITLE
Coveralls hotfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ notifications:
 # load travis-cargo
 before_script:
   - |
-      pip install 'travis-cargo<0.2' --user &&
-      export PATH=$HOME/.local/bin:$PATH
+      git clone git@github.com:Timidger/travis-cargo.git
+      (cd travi-cargo;
+      pip install -e . --user &&
+      export PATH=$HOME/.local/bin:$PATH)
 script:
   - cargo test --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
 before_script:
   - |
       git clone git@github.com:Timidger/travis-cargo.git
-      (cd travi-cargo;
+      (cd travis-cargo;
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ script:
   - cargo test --verbose
 
 after_success:
-  # upload the documentation from the build with stable (automatically only actually
-  # runs on the master branch, not individual PRs)
-  - travis-cargo --only stable doc-upload
   # measure code coverage and upload to coveralls.io (the verify
   # argument mitigates kcov crashes due to malformed debuginfo, at the
   # cost of some speed <https://github.com/huonw/travis-cargo/issues/12>)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - stable
+cache: cargo
 # necessary for `travis-cargo coveralls --no-sudo`
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 # load travis-cargo
 before_script:
   - |
-      git clone git@github.com:Timidger/travis-cargo.git
+      git clone https://github.com/Timidger/travis-cargo
       (cd travis-cargo;
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)


### PR DESCRIPTION
This fixes coveralls, by building it with a patch that hasn't been merged into the upstream yet. There are problems with testing the coveralls upload from Travis program against nightly using `dylib`, but since that's so niche I thought it prudent to maintain a fork until that is fixed.