### PR TITLE
Containers "remember" last active child

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -41,7 +41,7 @@ impl LayoutTree {
                                 match self.tree[new_active_ix].get_type() {
                                     ContainerType::Container => {
                                         let path_ix = self.tree.follow_path(new_active_ix);
-                                        // If the pat wasn't complete, find the first view and focus on that
+                                        // If the path wasn't complete, find the first view and focus on that
                                         let node_ix = (self.tree.descendant_of_type(path_ix, ContainerType::View)).unwrap();
                                         let parent_ix = (self.tree.parent_of(node_ix)).unwrap();
                                         match self.tree[node_ix].get_type() {

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -40,12 +40,17 @@ impl LayoutTree {
                                 let new_active_ix = siblings[new_index];
                                 match self.tree[new_active_ix].get_type() {
                                     ContainerType::Container => {
-                                        // Get the first view we can find in the container
-                                        let first_view = self.tree.descendant_of_type(new_active_ix, ContainerType::View)
-                                            .expect("Could not find view in ancestor sibling container");
+                                        let path_ix = self.tree.follow_path(new_active_ix);
+                                        // If the pat wasn't complete, find the first view and focus on that
+                                        let node_ix = (self.tree.descendant_of_type(path_ix, ContainerType::View)).unwrap();
+                                        let parent_ix = (self.tree.parent_of(node_ix)).unwrap();
+                                        match self.tree[node_ix].get_type() {
+                                            ContainerType::View | ContainerType::Container => {},
+                                            _ => panic!("Following path did not lead to a container or a view!")
+                                        }
                                         trace!("Moving to different view {:?} in container {:?}",
-                                                self.tree[first_view], self.tree[new_active_ix]);
-                                        return Ok(first_view);
+                                                self.tree[node_ix], self.tree[parent_ix]);
+                                        return Ok(node_ix);
                                     },
                                     ContainerType::View => {
                                         trace!("Moving to other view {:?}", self.tree[new_active_ix]);

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -42,7 +42,13 @@ impl LayoutTree {
                                     ContainerType::Container => {
                                         let path_ix = self.tree.follow_path(new_active_ix);
                                         // If the path wasn't complete, find the first view and focus on that
-                                        let node_ix = (self.tree.descendant_of_type(path_ix, ContainerType::View)).unwrap();
+                                        let node_ix = match self.tree.descendant_of_type(path_ix, ContainerType::View) {
+                                            Some(ix) => ix,
+                                            None => {
+                                                warn!("Could not find view while changing focus in a container");
+                                                return Err(())
+                                            }
+                                        };
                                         let parent_ix = (self.tree.parent_of(node_ix)).unwrap();
                                         match self.tree[node_ix].get_type() {
                                             ContainerType::View | ContainerType::Container => {},

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -105,13 +105,6 @@ impl LayoutTree {
         }
         // If this is reached, parent is workspace
         let container_ix = self.tree.children_of(parent_ix)[0];
-        // set the workspace to be active
-        match self.tree[parent_ix] {
-            Container::Workspace {ref mut focused, .. }=> {
-                *focused = true;
-            },
-            _ => unreachable!()
-        }
         let root_c_children = self.tree.children_of(container_ix);
         if root_c_children.len() > 0 {
             let new_active_ix = self.tree.descendant_of_type(root_c_children[0],

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -57,8 +57,6 @@ pub enum Container {
     Output {
         /// Handle to the wlc
         handle: WlcOutput,
-        /// Whether the output is focused
-        focused: bool,
         /// UUID associated with container, client program can use container
         id: Uuid,
     },
@@ -66,10 +64,6 @@ pub enum Container {
     Workspace {
         /// Name of the workspace
         name: String,
-        /// Whether the workspace is focused
-        ///
-        /// Multiple workspaces can be focused
-        focused: bool,
         /// The size of the workspace on the screen.
         /// Might be different if there is e.g a bar present
         size: Size,
@@ -80,8 +74,6 @@ pub enum Container {
     Container {
         /// How the container is layed out
         layout: Layout,
-        /// If the container is focused
-        focused: bool,
         /// If the container is floating
         floating: bool,
         /// The geometry of the container, relative to the parent container
@@ -93,8 +85,6 @@ pub enum Container {
     View {
         /// The wlc handle to the view
         handle: WlcView,
-        /// Whether this view is focused
-        focused: bool,
         /// Whether this view is floating
         floating: bool,
         /// UUID associated with container, client program can use container
@@ -111,7 +101,6 @@ impl Container {
     pub fn new_output(handle: WlcOutput) -> Container {
         Container::Output {
             handle: handle,
-            focused: false,
             id: Uuid::new_v4()
         }
     }
@@ -122,7 +111,6 @@ impl Container {
     pub fn new_workspace(name: String, size: Size) -> Container {
         Container::Workspace {
             name: name,
-            focused: false,
             size: size,
             id: Uuid::new_v4()
         }
@@ -132,7 +120,6 @@ impl Container {
     pub fn new_container(geometry: Geometry) -> Container {
         Container::Container {
             layout: Layout::Horizontal,
-            focused: false,
             floating: false,
             geometry: geometry,
             id: Uuid::new_v4()
@@ -143,7 +130,6 @@ impl Container {
     pub fn new_view(handle: WlcView) -> Container {
         Container::View {
             handle: handle,
-            focused: false,
             floating: false,
             id: Uuid::new_v4()
         }
@@ -187,28 +173,6 @@ impl Container {
         match *self {
             Container::Workspace { ref name, ..} => Some(name),
             _ => None
-        }
-    }
-
-    /// Determines if the container is focused or not
-    pub fn is_focused(&self) -> bool {
-        match *self {
-            Container::Root(_)  => false,
-            Container::Output { ref focused, .. } |
-            Container::Workspace { ref focused, .. } |
-            Container::Container { ref focused, .. } |
-            Container::View { ref focused, .. } => *focused,
-        }
-    }
-
-    /// Sets the focused value of the container
-    pub fn set_focused(&mut self, new_focused: bool) {
-        match *self {
-            Container::Root(_) => {},
-            Container::Output { ref mut focused, .. } |
-            Container::Workspace { ref mut focused, .. } |
-            Container::Container { ref mut focused, .. } |
-            Container::View { ref mut focused, .. } => *focused = new_focused,
         }
     }
 
@@ -361,24 +325,6 @@ mod tests {
                 let result = container.set_layout(*new_layout);
                 assert!(result.is_err());
             }
-        }
-    }
-
-    #[test]
-    fn is_focused_test() {
-        let root = Container::new_root();
-        let output = Container::new_output(WlcView::root().as_output());
-        let workspace = Container::new_workspace("1".to_string(),
-                                                 Size { w: 500, h: 500 });
-        let container = Container::new_container(Geometry {
-            origin: Point { x: 0, y: 0},
-            size: Size { w: 0, h:0}
-        });
-        let view = Container::new_view(WlcView::root());
-        for container in &mut [root.clone(), output.clone(),
-                               container.clone(),
-                               workspace.clone(), view.clone()] {
-            assert_eq!(container.is_focused(), false);
         }
     }
 }

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -204,10 +204,14 @@ impl InnerTree {
             return Err(GraphError::NotSiblings(child1_ix, child2_ix))
         }
         let parent_ix = parent2_ix;
-        let child1_weight = *self.get_edge_weight_between(parent_ix, child1_ix)
+        let mut child1_weight = *self.get_edge_weight_between(parent_ix, child1_ix)
             .expect("Could not get weight between parent and child");
-        let child2_weight = *self.get_edge_weight_between(parent_ix, child2_ix)
+        let mut child2_weight = *self.get_edge_weight_between(parent_ix, child2_ix)
             .expect("Could not get weight between parent and child");
+        // We don't want to swap the active flag
+        child1_weight.active = child1_weight.active ^ child2_weight.active;
+        child2_weight.active = child1_weight.active ^ child2_weight.active;
+        child1_weight.active = child1_weight.active ^ child2_weight.active;
         self.graph.update_edge(parent_ix, child1_ix, child2_weight);
         self.graph.update_edge(parent_ix, child2_ix, child1_weight);
         self.normalize_edge_weights(parent1_ix);

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -189,7 +189,7 @@ impl InnerTree {
             self.graph.update_edge(parent_ix, sibling_ix, edge_weight);
             counter += 1;
         }
-	let last_pos = PathBuilder::new(child_pos).active(true).build();
+        let last_pos = PathBuilder::new(child_pos).active(true).build();
         self.graph.update_edge(parent_ix, child_ix, last_pos);
         self.normalize_edge_weights(parent_ix);
     }

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -258,6 +258,7 @@ impl InnerTree {
                 self.graph.edge_weight(target_parent_edge).map(|weight| {
                     let mut new_weight = *weight;
                     *new_weight = *new_weight + 1;
+                    new_weight.active = true;
                     new_weight
                 })
             }
@@ -275,6 +276,7 @@ impl InnerTree {
                 .expect("Could not get the weight of the edge between target sibling and target parent");
             trace!("Sibling {:?} previously had an edge weight of {:?} to {:?}", sibling_ix, weight, target_parent);
             **weight = **weight + 1;
+            weight.active = false;
             trace!("Sibling {:?}, edge weight to {:?} is now {:?}", sibling_ix, target_parent, weight);
         }
         trace!("Removing edge between child {:?} and parent {:?}", source, source_parent);

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -531,6 +531,8 @@ impl InnerTree {
     }
 
     /// Attempts to get an ancestor matching the matching type
+    ///
+    /// Note this does *NOT* check the given node.
     pub fn ancestor_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {
         let mut curr_ix = node_ix;
@@ -547,6 +549,8 @@ impl InnerTree {
 
     /// Attempts to get a descendant of the matching type
     /// Looks down the left side of the tree first
+    ///
+    /// Note this *DOES* check the given node.
     pub fn descendant_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {
         if let Some(container) = self.get(node_ix) {

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -533,11 +533,6 @@ impl InnerTree {
     /// Attempts to get an ancestor matching the matching type
     pub fn ancestor_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {
-        if let Some(container) = self.get(node_ix) {
-            if container.get_type() == container_type {
-                return Some(node_ix)
-            }
-        }
         let mut curr_ix = node_ix;
         while let Some(parent_ix) = self.parent_of(curr_ix) {
             let parent = self.graph.node_weight(parent_ix)

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -8,7 +8,7 @@ use std::fmt::{Debug, Formatter};
 use std::fmt::Result as FmtResult;
 
 use petgraph::EdgeDirection;
-use petgraph::graph::{Graph, NodeIndex, EdgeIndex};
+use petgraph::graph::{Graph, NodeIndex};
 use uuid::Uuid;
 
 use rustwlc::WlcView;
@@ -146,8 +146,7 @@ impl InnerTree {
 
     /// Add an existing node (detached in the graph) to the tree.
     /// Note that floating nodes shouldn't exist for too long.
-    pub fn attach_child(&mut self, parent_ix: NodeIndex, child_ix: NodeIndex)
-                     -> EdgeIndex {
+    pub fn attach_child(&mut self, parent_ix: NodeIndex, child_ix: NodeIndex) {
         // Make sure the child doesn't have a parent
         if cfg!(debug_assertions) && self.has_parent(child_ix) {
             panic!("attach_child: child had a parent!")
@@ -164,9 +163,8 @@ impl InnerTree {
         }
         let (_ix, mut biggest_child) = self.largest_child(parent_ix);
         *biggest_child += 1;
-        let result = self.graph.update_edge(parent_ix, child_ix, biggest_child);
+        self.graph.update_edge(parent_ix, child_ix, biggest_child);
         self.normalize_edge_weights(parent_ix);
-        result
     }
 
     /// Finds the index of the container at the child index's parent,

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -140,6 +140,7 @@ impl InnerTree {
         let id = val.get_id();
         let child_ix = self.graph.add_node(val);
         self.attach_child(parent_ix, child_ix);
+        self.set_ancestor_paths_active(child_ix);
         self.id_map.insert(id, child_ix);
         child_ix
     }

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -533,6 +533,11 @@ impl InnerTree {
     /// Attempts to get an ancestor matching the matching type
     pub fn ancestor_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {
+        if let Some(container) = self.get(node_ix) {
+            if container.get_type() == container_type {
+                return Some(node_ix)
+            }
+        }
         let mut curr_ix = node_ix;
         while let Some(parent_ix) = self.parent_of(curr_ix) {
             let parent = self.graph.node_weight(parent_ix)

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -159,11 +159,15 @@ impl InnerTree {
 
     /// Adds a new child to a node at the index, returning the node index
     /// of the new child node.
-    pub fn add_child(&mut self, parent_ix: NodeIndex, val: Container) -> NodeIndex {
+    ///
+    /// If active is true, the path to the new node is made active.
+    pub fn add_child(&mut self, parent_ix: NodeIndex, val: Container, active: bool) -> NodeIndex {
         let id = val.get_id();
         let child_ix = self.graph.add_node(val);
         self.attach_child(parent_ix, child_ix);
-        self.set_ancestor_paths_active(child_ix);
+        if active {
+            self.set_ancestor_paths_active(child_ix);
+        }
         self.id_map.insert(id, child_ix);
         child_ix
     }
@@ -450,7 +454,6 @@ impl InnerTree {
     pub fn move_node(&mut self, node_ix: NodeIndex, new_parent: NodeIndex) {
         self.detach(node_ix);
         self.attach_child(new_parent, node_ix);
-        self.set_ancestor_paths_active(node_ix);
     }
 
     /// Whether a node has a parent
@@ -722,27 +725,27 @@ mod tests {
             origin: Point { x: 0, y: 0 }
         };
 
-        let output_ix = tree.add_child(root_ix, Container::new_output(fake_output));
+        let output_ix = tree.add_child(root_ix, Container::new_output(fake_output), false);
         let workspace_1_ix = tree.add_child(output_ix,
                                                 Container::new_workspace("1".to_string(),
-                                                                   fake_size.clone()));
+                                                                   fake_size.clone()), false);
         let root_container_1_ix = tree.add_child(workspace_1_ix,
-                                                Container::new_container(fake_geometry.clone()));
+                                                Container::new_container(fake_geometry.clone()), false);
         let workspace_2_ix = tree.add_child(output_ix,
                                                 Container::new_workspace("2".to_string(),
-                                                                     fake_size.clone()));
+                                                                     fake_size.clone()), false);
         let root_container_2_ix = tree.add_child(workspace_2_ix,
-                                                Container::new_container(fake_geometry.clone()));
+                                                Container::new_container(fake_geometry.clone()), false);
         /* Workspace 1 containers */
         let wkspc_1_view = tree.add_child(root_container_1_ix,
-                                                Container::new_view(fake_view_1.clone()));
+                                                Container::new_view(fake_view_1.clone()), false);
         /* Workspace 2 containers */
         let wkspc_2_container = tree.add_child(root_container_2_ix,
-                                                Container::new_container(fake_geometry.clone()));
+                                                Container::new_container(fake_geometry.clone()), false);
         let wkspc_2_sub_view_1 = tree.add_child(wkspc_2_container,
-                                                Container::new_view(fake_view_1.clone()));
+                                                Container::new_view(fake_view_1.clone()), false);
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
-                                                Container::new_view(fake_view_1.clone()));
+                                                Container::new_view(fake_view_1.clone()), false);
         tree
     }
 
@@ -781,7 +784,7 @@ mod tests {
         let root_container_ix = tree.descendant_of_type(root_ix, ContainerType::Container).unwrap();
         let container = Container::new_view(fake_view);
         let container_uuid = container.get_id();
-        tree.add_child(root_container_ix, container.clone());
+        tree.add_child(root_container_ix, container.clone(), false);
         let only_view = &tree[tree.descendant_of_type(root_ix, ContainerType::View).unwrap()];
         assert_eq!(*only_view, container);
         assert_eq!(only_view.get_id(), container_uuid);

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -594,6 +594,29 @@ impl InnerTree {
             self.graph.node_count() - 1 == node_ix.index()
         }
     }
+
+    /// Modifies the ancestor paths so that the only complete path from the root
+    /// goes to this node.
+    ///
+    /// If a divergent path is detected, that edge is deactivated in favor of
+    /// the one that leads to this node.
+    pub fn set_ancestor_paths_active(&mut self, mut node_ix: NodeIndex) {
+        while let Some(parent_ix) = self.parent_of(node_ix) {
+            for child_ix in self.children_of(parent_ix) {
+                let edge_ix = self.graph.find_edge(parent_ix, child_ix)
+                    .expect("Could not get edge index between parent and child");
+                let edge = self.graph.edge_weight_mut(edge_ix)
+                    .expect("Could not associate edge index with an edge weight");
+                edge.active = false;
+            }
+            let edge_ix = self.graph.find_edge(parent_ix, node_ix)
+                .expect("Could not get edge index between parent and child");
+            let edge = self.graph.edge_weight_mut(edge_ix)
+                .expect("Could not associate edge index with an edge weight");
+            edge.active = true;
+            node_ix = parent_ix;
+        }
+    }
 }
 
 use std::ops::{Index, IndexMut};

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -652,6 +652,14 @@ impl InnerTree {
     /// If a divergent path is detected, that edge is deactivated in favor of
     /// the one that leads to this node.
     pub fn set_ancestor_paths_active(&mut self, mut node_ix: NodeIndex) {
+        // Make sure that any children of this node are inactive
+        for child_ix in self.children_of(node_ix) {
+            let edge_ix = self.graph.find_edge(node_ix, child_ix)
+                .expect("Could not get edge index between parent and child");
+            let edge = self.graph.edge_weight_mut(edge_ix)
+                .expect("Could not associate edge index with an edge weight");
+            edge.active = false;
+        }
         while let Some(parent_ix) = self.parent_of(node_ix) {
             for child_ix in self.children_of(parent_ix) {
                 let edge_ix = self.graph.find_edge(parent_ix, child_ix)
@@ -735,7 +743,6 @@ mod tests {
                                                 Container::new_view(fake_view_1.clone()));
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
                                                 Container::new_view(fake_view_1.clone()));
-        tree[workspace_1_ix].set_focused(true);
         tree
     }
 

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -97,6 +97,22 @@ impl InnerTree {
         result
     }
 
+    /// Follows the active path beneath the node until it ends.
+    /// Returns the last node in the chain.
+    pub fn follow_path(&self, node_ix: NodeIndex) -> NodeIndex {
+        let mut next_ix = Some(node_ix);
+        while let Some(cur_ix) = next_ix {
+            let maybe_edge = self.graph.edges_directed(cur_ix, EdgeDirection::Outgoing)
+                .find(|&(_, weight): &(_, &Path)| weight.active);
+            if let Some(edge) = maybe_edge {
+                next_ix = Some(edge.0);
+            } else {
+                return cur_ix
+            }
+        }
+        node_ix
+    }
+
     /// Gets the weight of a possible edge between two notes
     pub fn get_edge_weight_between(&self, parent_ix: NodeIndex,
                                    child_ix: NodeIndex) -> Option<&Path> {

--- a/src/layout/core/path.rs
+++ b/src/layout/core/path.rs
@@ -23,7 +23,7 @@ impl PathBuilder {
     ///
     /// Active is set to false automatically
     pub fn new(weight: u32) -> Self {
-        PathBuilder { path: Path { weight: weight, active: true } }
+        PathBuilder { path: Path { weight: weight, active: false } }
     }
 
     pub fn active(mut self, value: bool) -> Self {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -658,6 +658,24 @@ impl LayoutTree {
             }
         }
         validate_edge_count(self, self.tree.root_ix());
+
+        // Ensure there is only one active path from the root
+        let mut next_ix = Some(self.tree.root_ix());
+        while let Some(cur_ix) = next_ix {
+            next_ix = None;
+            let mut flipped = false;
+            for child_ix in self.tree.children_of(cur_ix) {
+                let weight = *self.tree.get_edge_weight_between(cur_ix, child_ix)
+                    .expect("Could not get edge weights between child and parent");
+                if weight.active && flipped {
+                    error!("Divergent paths detected!");
+                    trace!("Tree: {:#?}", self);
+                    panic!("Divergent paths detected!");
+                }  else if weight.active {
+                    flipped = true;
+                }
+            }
+        }
     }
 
     #[cfg(not(debug_assertions))]

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -741,7 +741,7 @@ pub mod tests {
         let wkspc_2_container = tree.add_child(root_container_2_ix,
                                                 Container::new_container(fake_geometry.clone()), false);
         let wkspc_2_sub_view_1 = tree.add_child(wkspc_2_container,
-                                                Container::new_view(fake_view_1.clone()), false);
+                                                Container::new_view(fake_view_1.clone()), true);
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
                                                 Container::new_view(fake_view_1.clone()), false);
         let mut layout_tree = LayoutTree {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -687,15 +687,6 @@ impl LayoutTree {
                 }
             }
         }
-
-        // Ensure the root path points to the active container (if there is one)
-        if let Some(active_ix) = self.active_container {
-            if active_ix != self.tree.follow_path(self.tree.root_ix()) {
-                error!("Path did not lead to the active container!");
-                trace!("Tree: {:#?}", self);
-                panic!("Path did not lead to the active container!");
-            }
-        }
     }
 
     #[cfg(not(debug_assertions))]

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -91,13 +91,7 @@ impl LayoutTree {
             _ => {}
         }
         info!("Active container is now: {:?}", self.active_container);
-        // NOTE Active workspace hack, remove when paths are added
-        let workspace_ix = self.tree.ancestor_of_type(node_ix, ContainerType::Workspace)
-            .expect("Container was not associated with a workspace");
-        let mut workspace = &mut self.tree[workspace_ix];
-        trace!("Setting {} to be the active workspace", workspace.get_name()
-               .expect("Workspace had no name"));
-        workspace.set_focused(true);
+        self.tree.set_ancestor_paths_active(node_ix);
     }
 
     /// Unsets the active container. This should be used when focusing on

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -736,8 +736,6 @@ pub mod tests {
                                                 Container::new_view(fake_view_1.clone()));
         let wkspc_2_sub_view_2 = tree.add_child(wkspc_2_container,
                                                 Container::new_view(fake_view_1.clone()));
-
-        tree[workspace_1_ix].set_focused(true);
         let layout_tree = LayoutTree {
             tree: tree,
             active_container: Some(wkspc_1_view)
@@ -1204,15 +1202,11 @@ pub mod tests {
         let workspace_ix = tree.active_ix_of(ContainerType::Workspace)
             .expect("Active container wasn't set properly in basic_tree!");
         assert_eq!(tree.tree[workspace_ix].get_name(), Some("1"));
-        assert!(tree.tree[workspace_ix].is_focused(),
-                "Workspace needs to be focused to be able to switch");
         tree.active_container = None;
         tree.switch_to_workspace("2");
         let workspace_ix = tree.active_ix_of(ContainerType::Workspace)
             .expect("The new workspace was not set!");
         assert_eq!(tree.tree[workspace_ix].get_name(), Some("2"));
-        assert!(tree.tree[workspace_ix].is_focused(),
-                "Switching to a workspace should make it focused");
     }
 
     #[test]
@@ -1221,13 +1215,9 @@ pub mod tests {
         let workspace_ix = tree.active_ix_of(ContainerType::Workspace)
             .expect("Active container wasn't set properly in basic_tree!");
         assert_eq!(tree.tree[workspace_ix].get_name(), Some("1"));
-        assert!(tree.tree[workspace_ix].is_focused(),
-                "Workspace needs to be focused to be able to switch");
         tree.switch_to_workspace("2");
         let workspace_ix = tree.active_ix_of(ContainerType::Workspace)
             .expect("Active container wasn't set properly in basic_tree!");
         assert_eq!(tree.tree[workspace_ix].get_name(), Some("2"));
-        assert!(tree.tree[workspace_ix].is_focused(),
-                "Switching to a workspace should make it focused");
     }
 }

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -62,6 +62,8 @@ impl LayoutTree {
 
     /// Sets the active container associated with the UUID to be the active container.
     ///
+    /// Updates the active path accordingly
+    ///
     /// If the container was not a view or container, or the UUID was invalid,
     /// then an error is returned.
     pub fn set_active_container(&mut self, id: Uuid) -> Result<(), TreeError>{
@@ -70,6 +72,7 @@ impl LayoutTree {
         match self.tree[node_ix].get_type() {
             ContainerType::View { .. } | ContainerType::Container { .. } => {
                 self.active_container = Some(node_ix);
+                self.tree.set_ancestor_paths_active(node_ix);
                 Ok(())
             },
             _ => {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -681,6 +681,15 @@ impl LayoutTree {
                 }
             }
         }
+
+        // Ensure the root path points to the active container (if there is one)
+        if let Some(active_ix) = self.active_container {
+            if active_ix != self.tree.follow_path(self.tree.root_ix()) {
+                error!("Path did not lead to the active container!");
+                trace!("Tree: {:#?}", self);
+                panic!("Path did not lead to the active container!");
+            }
+        }
     }
 
     #[cfg(not(debug_assertions))]

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -493,10 +493,16 @@ impl LayoutTree {
         workspace_ix = self.tree.workspace_ix_by_name(name)
             .expect("Workspace we just made was deleted!");
         let active_ix = self.tree.follow_path(workspace_ix);
-        match self.tree[active_ix] {
-            Container::View { ref handle, .. } => {
+        match self.tree[active_ix].get_type() {
+            ContainerType::View  => {
+                match self.tree[active_ix] {
+                    Container::View { ref handle, ..} => {
+                        handle.focus();
+                    },
+                    _ => unreachable!()
+                }
                 self.active_container = Some(active_ix);
-                handle.focus();
+                self.tree.set_ancestor_paths_active(active_ix);
                 self.validate();
                 return;
             },

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -123,24 +123,28 @@ impl LayoutTree {
 
     /// Gets the index of the currently active container with the given type.
     /// Starts at the active container, moves up until either a container with
-    /// that type is found or the root node is hit
+    /// that type is found or the root node is hit.
+    ///
+    /// If the active_container is not set, the active path is used
+    /// to find the active container.
     pub fn active_ix_of(&self, ctype: ContainerType) -> Option<NodeIndex> {
         if let Some(ix) = self.active_container {
             if self.tree[ix].get_type() == ctype {
-                return Some(ix)
+                Some(ix)
+            } else {
+                self.tree.ancestor_of_type(ix, ctype)
             }
-            return self.tree.ancestor_of_type(ix, ctype)
         } else {
-            let workspaces: Vec<NodeIndex> = self.tree.all_descendants_of(&self.tree.root_ix())
-                .into_iter().filter(|ix| self.tree[*ix].get_type() == ContainerType::Workspace)
-                .collect();
-            for workspace_ix in workspaces {
-                if self.tree[workspace_ix].is_focused() {
-                    return self.tree.ancestor_of_type(workspace_ix, ctype)
-                }
+            // follow path to find the active container
+            let active_ix = self.tree.follow_path(self.tree.root_ix());
+            println!("active_ix: {:?}", active_ix);
+            println!("tree: {:#?}", self);
+            if self.tree[active_ix].get_type() == ctype {
+                Some(active_ix)
+            } else {
+                self.tree.ancestor_of_type(active_ix, ctype)
             }
         }
-        return None
 
     }
 
@@ -818,15 +822,13 @@ pub mod tests {
     fn active_container_test() {
         let mut tree = basic_tree();
         tree.active_container = None;
-        assert_eq!(tree.get_active_container(), None);
-        assert_eq!(tree.get_active_parent(), None);
-        assert_eq!(tree.active_ix_of(ContainerType::View), None);
-        assert_eq!(tree.active_ix_of(ContainerType::Container), None);
-        assert_eq!(tree.active_ix_of(ContainerType::Workspace), None);
-        /* These are true because we know the workspace was the last used
-         * Eventually they should all be true because of paths, but because
-         * of a hack these are now Some(_)
-         */
+        // These will be None, because the pointer is None
+        assert!(tree.get_active_container().is_none());
+        assert!(tree.get_active_parent().is_none());
+        // These will be Some, because the path still leads there
+        assert!(tree.active_ix_of(ContainerType::View).is_some());
+        assert!(tree.active_ix_of(ContainerType::Container).is_some());
+        assert!(tree.active_ix_of(ContainerType::Workspace).is_some());
         assert!(tree.active_ix_of(ContainerType::Output).is_some());
         assert!(tree.active_ix_of(ContainerType::Root).is_some());
         tree.set_active_view(WlcView::root());


### PR DESCRIPTION
When switching from a container, when you switch back to it the first view that is focused is now always the last one you focused one. This works while switching workspaces and moving views between containers/workspaces.

Some other small changes resulted from this:

* `focused` flag in the containers was removed.
* Debug printing the tree prints the active path from the root.
* `PathBuilder` no longer assumes a new path is active, you need to set it explicitly.
* Active workspace hack was removed (since the `focused` flag was the main backing of it). Paths replaces this concept.
* `add_child` requires a`bool` to determine whether to activate the new child`s path or not.

Note that the point of the "active path" is not to be a duplicate of the `active_container`. The `active_container` should still be used in most places, because it represents what the user is actually focused on for sure.

The active path points last known active container, but not necessarily the current active container. 