### PR TITLE
Tree cleanup

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -50,7 +50,7 @@ impl LayoutTree {
                                 match self.tree[new_active_ix].get_type() {
                                     ContainerType::Container => {
                                         let path_ix = self.tree.follow_path(new_active_ix);
-                                        // If the pat wasn't complete, find the first view and focus on that
+                                        // If the path wasn't complete, find the first view and focus on that
                                         let node_ix = (self.tree.descendant_of_type(path_ix, ContainerType::View)).unwrap();
                                         let parent_ix = try!(self.tree.parent_of(node_ix).map_err(|err| TreeError::PetGraphError(err)));
                                         match self.tree[node_ix].get_type() {

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -40,12 +40,17 @@ impl LayoutTree {
                                 let new_active_ix = siblings[new_index];
                                 match self.tree[new_active_ix].get_type() {
                                     ContainerType::Container => {
-                                        // Get the first view we can find in the container
-                                        let first_view = self.tree.descendant_of_type(new_active_ix, ContainerType::View)
-                                            .expect("Could not find view in ancestor sibling container");
+                                        let path_ix = self.tree.follow_path(new_active_ix);
+                                        // If the pat wasn't complete, find the first view and focus on that
+                                        let node_ix = (self.tree.descendant_of_type(path_ix, ContainerType::View)).unwrap();
+                                        let parent_ix = (self.tree.parent_of(node_ix)).unwrap();
+                                        match self.tree[node_ix].get_type() {
+                                            ContainerType::View | ContainerType::Container => {},
+                                            _ => panic!("Following path did not lead to a container or a view!")
+                                        }
                                         trace!("Moving to different view {:?} in container {:?}",
-                                                self.tree[first_view], self.tree[new_active_ix]);
-                                        return Ok(first_view);
+                                                self.tree[node_ix], self.tree[parent_ix]);
+                                        return Ok(node_ix);
                                     },
                                     ContainerType::View => {
                                         trace!("Moving to other view {:?}", self.tree[new_active_ix]);

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -168,7 +168,7 @@ impl LayoutTree {
         });
     }
 
-    /// Normalizes the geometry of a view to be the same size as it's siblings,
+    /// Normalizes the geometry of a view to be the same size as its siblings,
     /// based on the parent container's layout, at the 0 point of the parent container.
     /// Note this does not auto-tile, only modifies this one view.
     ///

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -51,8 +51,10 @@ impl LayoutTree {
                                     ContainerType::Container => {
                                         let path_ix = self.tree.follow_path(new_active_ix);
                                         // If the path wasn't complete, find the first view and focus on that
-                                        let node_ix = (self.tree.descendant_of_type(path_ix, ContainerType::View)).unwrap();
-                                        let parent_ix = try!(self.tree.parent_of(node_ix).map_err(|err| TreeError::PetGraphError(err)));
+                                        let node_ix = self.tree.descendant_of_type(path_ix, ContainerType::View)
+                                            .unwrap();
+                                        let parent_ix = try!(self.tree.parent_of(node_ix)
+                                                             .map_err(|err| TreeError::PetGraph(err)));
                                         match self.tree[node_ix].get_type() {
                                             ContainerType::View | ContainerType::Container => {},
                                             _ => panic!("Following path did not lead to a container or a view!")

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -167,4 +167,16 @@ impl LayoutTree {
             _ => panic!("Active container not view or container!")
         });
     }
+
+    /// Normalizes the geometry of a view to be the same size as it's siblings,
+    /// based on the parent container's layout, at the 0 point of the parent container.
+    /// Note this does not auto-tile, only modifies this one view.
+    ///
+    /// Useful if a container's children want to be evenly distributed, or a new view
+    /// is being added.
+    pub fn normalize_view(&mut self, view: WlcView) {
+        if let Some(view_ix) = self.tree.descendant_with_handle(self.tree.root_ix(), &view) {
+            self.normalize_container(view_ix);
+        }
+    }
 }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -259,7 +259,7 @@ impl LayoutTree {
     /// * else, make it horizontal
     /// This method does *NOT* update the actual views geometry, that needs to be
     /// done separately by the caller
-    pub fn toggle_active_horizontal(&mut self) {
+    pub fn toggle_cardinal_tiling(&mut self) {
         if let Some(active_ix) = self.active_ix_of(ContainerType::Container) {
             trace!("Toggling {:?} to be horizontal or vertical...", self.tree[active_ix]);
             match self.tree[active_ix] {

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -4,6 +4,7 @@ use petgraph::graph::NodeIndex;
 use rustwlc::{Geometry, Point, Size, ResizeEdge};
 
 use super::super::LayoutTree;
+use super::super::commands::CommandResult;
 use super::super::core::container::{Container, ContainerType, Layout};
 
 impl LayoutTree {
@@ -196,6 +197,35 @@ impl LayoutTree {
         self.validate();
     }
 
+    /// Changes the layout of the active container to the given layout.
+    /// If the active container is a view, a new container is added with the given
+    /// layout type.
+    pub fn toggle_active_layout(&mut self, new_layout: Layout) -> CommandResult {
+        if let Some(active_ix) = self.active_container {
+            let parent_ix = self.tree.parent_of(active_ix)
+                .expect("Active container had no parent");
+            if self.tree.is_root_container(active_ix) {
+                self.set_layout(active_ix, new_layout);
+                return Ok(())
+            }
+            if self.tree.children_of(parent_ix).len() == 1 {
+                self.set_layout(parent_ix, new_layout);
+                return Ok(())
+            }
+
+            let active_geometry = self.get_active_container()
+                .expect("Could not get the active container")
+                .get_geometry().expect("Active container had no geometry");
+
+            let mut new_container = Container::new_container(active_geometry);
+            new_container.set_layout(new_layout).ok();
+            try!(self.add_container(new_container, active_ix));
+            // add_container sets the active container to be the new container
+            try!(self.set_active_node(active_ix));
+        }
+        self.validate();
+        Ok(())
+    }
 
     // Updates the tree's layout recursively starting from the active container.
     // If the active container is a view, it starts at the parent container.
@@ -223,6 +253,36 @@ impl LayoutTree {
         }
         self.validate();
     }
+
+    /// Gets the active container and toggles it based on the following rules:
+    /// * If horizontal, make it vertical
+    /// * else, make it horizontal
+    /// This method does *NOT* update the actual views geometry, that needs to be
+    /// done separately by the caller
+    pub fn toggle_active_horizontal(&mut self) {
+        if let Some(active_ix) = self.active_ix_of(ContainerType::Container) {
+            trace!("Toggling {:?} to be horizontal or vertical...", self.tree[active_ix]);
+            match self.tree[active_ix] {
+                Container::Container { ref mut layout, .. } => {
+                    match *layout {
+                        Layout::Horizontal => {
+                            trace!("Toggling to be vertical");
+                            *layout = Layout::Vertical
+                        }
+                        _ => {
+                            trace!("Toggling to be horizontal");
+                            *layout = Layout::Horizontal
+                        }
+                    }
+                },
+                _ => unreachable!()
+            }
+        } else {
+            error!("No active container")
+        }
+        self.validate();
+    }
+
 
     /// Calculates how much to scale on average for each value given.
     /// If the value is 0 (i.e the width or height of the container is 0),

--- a/src/layout/actions/mod.rs
+++ b/src/layout/actions/mod.rs
@@ -1,3 +1,4 @@
 pub mod layout;
 pub mod movement;
 pub mod focus;
+pub mod workspace;

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -248,7 +248,7 @@ mod tests {
         let children = tree.tree.children_of(active_parent);
         assert_eq!(children[1], tree.active_container.unwrap());
         // test going up and down works
-        tree.toggle_active_horizontal();
+        tree.toggle_cardinal_tiling();
         assert!(tree.move_container(active_uuid, Direction::Up).is_ok());
         let children = tree.tree.children_of(active_parent);
         assert_eq!(children[0], tree.active_container.unwrap());

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn test_basic_move() {
         let mut tree = basic_tree();
-        tree.add_view(WlcView::root());
+        tree.add_view(WlcView::root()).unwrap();
         let active_uuid = tree.get_active_container().unwrap().get_id();
         let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
         let children = tree.tree.children_of(active_parent);
@@ -256,7 +256,7 @@ mod tests {
         let children = tree.tree.children_of(active_parent);
         assert_eq!(Some(children[0]), tree.active_container);
         // make the first view have a vertical layout
-        tree.toggle_active_layout(Layout::Vertical);
+        tree.toggle_active_layout(Layout::Vertical).unwrap();
         tree.active_container = Some(children[1]);
         let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
         let children = tree.tree.children_of(active_parent);
@@ -285,7 +285,7 @@ mod tests {
         let children = tree.tree.children_of(active_parent);
         assert_eq!(Some(children[0]), tree.active_container);
         // make the first view have a vertical layout
-        tree.toggle_active_layout(Layout::Horizontal);
+        tree.toggle_active_layout(Layout::Horizontal).unwrap();
         let horizontal_id = tree.tree[tree.tree.parent_of(tree.active_container.unwrap()).unwrap()].get_id();
         tree.active_container = Some(children[1]);
         let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
@@ -319,7 +319,7 @@ mod tests {
             let children = tree.tree.children_of(active_parent);
             assert_eq!(Some(children[0]), tree.active_container);
             // make the first view have a vertical layout
-            tree.toggle_active_layout(Layout::Horizontal);
+            tree.toggle_active_layout(Layout::Horizontal).unwrap();
             tree.active_container = Some(children[1]);
             let active_parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
             let children = tree.tree.children_of(active_parent);

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -1,0 +1,177 @@
+use petgraph::graph::NodeIndex;
+use rustwlc::{Geometry, Point};
+use super::super::LayoutTree;
+use super::super::core::container::{Container, ContainerType};
+
+impl LayoutTree {
+    /// Gets a workspace by name or creates it
+    fn get_or_make_workspace(&mut self, name: &str) -> NodeIndex {
+        let active_index = self.active_ix_of(ContainerType::Output)
+            .or_else(|| self.tree.follow_path_until(self.tree.root_ix(), ContainerType::Output).ok())
+            .expect("get_or_make_wksp: Couldn't get output");
+        let workspace_ix = self.tree.workspace_ix_by_name(name).unwrap_or_else(|| {
+            let root_ix = self.init_workspace(name.to_string(), active_index);
+            self.tree.parent_of(root_ix)
+                .expect("Workspace was not properly initialized with a root container")
+        });
+        self.validate();
+        workspace_ix
+    }
+
+    /// Initializes a workspace and gets the index of the root container
+    pub fn init_workspace(&mut self, name: String, output_ix: NodeIndex)
+                      -> NodeIndex {
+        let size = self.tree.get(output_ix)
+            .expect("init_workspace: invalid output").get_geometry()
+            .expect("init_workspace: no geometry for output").size;
+        let worksp = Container::new_workspace(name.to_string(), size.clone());
+
+        trace!("Adding workspace {:?}", worksp);
+        let worksp_ix = self.tree.add_child(output_ix, worksp, false);
+        let geometry = Geometry {
+            size: size, origin: Point { x: 0, y: 0 }
+        };
+        let container_ix = self.tree.add_child(worksp_ix,
+                                               Container::new_container(geometry), false);
+        self.validate();
+        container_ix
+    }
+
+    /// Switch to the specified workspace
+    pub fn switch_to_workspace(&mut self, name: &str) {
+        let maybe_active_ix = self.active_container
+            .or_else(|| {
+                let new_active = self.tree.follow_path(self.tree.root_ix());
+                match self.tree[new_active].get_type() {
+                    ContainerType::View | ContainerType::Container => {
+                        Some(new_active)
+                    },
+                    // else try and get the root container
+                    _ => self.tree.descendant_of_type(new_active, ContainerType::Container)
+                }
+            });
+        if maybe_active_ix.is_none() {
+            warn!("{:#?}", self);
+            warn!("No active container, cannot switch");
+            return;
+        }
+        let active_ix = maybe_active_ix.unwrap();
+        // Get the old (current) workspace
+        let old_worksp_ix: NodeIndex;
+        if let Some(index) = self.tree.ancestor_of_type(active_ix, ContainerType::Workspace) {
+            old_worksp_ix = index;
+            trace!("Switching to workspace {}", name);
+        } else {
+            match self.tree[active_ix].get_type() {
+                ContainerType::Workspace => {
+                    old_worksp_ix = active_ix;
+                    trace!("Switching to workspace {}", name);
+                },
+                _ => {
+                    warn!("Could not find old workspace, could not set invisible");
+                    return;
+                }
+            }
+        }
+        // Get the new workspace, or create one if it doesn't work
+        let mut workspace_ix = self.get_or_make_workspace(name);
+        if old_worksp_ix == workspace_ix {
+            return;
+        }
+        // Set the old one to invisible
+        self.tree.set_family_visible(old_worksp_ix, false);
+        // Set the new one to visible
+        self.tree.set_family_visible(workspace_ix, true);
+        // Delete the old workspace if it has no views on it
+        self.active_container = None;
+        if self.tree.descendant_of_type(old_worksp_ix, ContainerType::View).is_none() {
+            trace!("Removing workspace: {:?}", self.tree[old_worksp_ix].get_name()
+                   .expect("Workspace had no name"));
+            self.remove_container(old_worksp_ix);
+        }
+        workspace_ix = self.tree.workspace_ix_by_name(name)
+            .expect("Workspace we just made was deleted!");
+        let active_ix = self.tree.follow_path(workspace_ix);
+        match self.tree[active_ix].get_type() {
+            ContainerType::View  => {
+                match self.tree[active_ix] {
+                    Container::View { ref handle, ..} => {
+                        handle.focus();
+                    },
+                    _ => unreachable!()
+                }
+                self.active_container = Some(active_ix);
+                self.tree.set_ancestor_paths_active(active_ix);
+                self.validate();
+                return;
+            },
+            _ => {
+                self.active_container = self.tree.descendant_of_type(active_ix, ContainerType::View)
+                    .or_else(|| self.tree.descendant_of_type(active_ix, ContainerType::Container));
+            }
+        }
+        self.focus_on_next_container(workspace_ix);
+        self.validate();
+    }
+
+    /// Moves the current active container to a new workspace
+    pub fn send_active_to_workspace(&mut self, name: &str) {
+        // Ensure focus
+        if let Some(active_ix) = self.active_container {
+            let curr_work_ix = self.active_ix_of(ContainerType::Workspace)
+                .expect("send_active: Not currently in a workspace!");
+            if active_ix == self.tree.children_of(curr_work_ix)[0] {
+                warn!("Tried to move the root container of a workspace, aborting move");
+                return;
+            }
+            let next_work_ix = self.get_or_make_workspace(name);
+
+            // Check if the workspaces are the same
+            if next_work_ix == curr_work_ix {
+                trace!("Attempted to move a view to the same workspace {}!", name);
+                return;
+            }
+            self.tree.set_family_visible(curr_work_ix, false);
+
+            // Save the parent of this view for focusing
+            let maybe_active_parent = self.tree.parent_of(active_ix);
+
+            // Get the root container of the next workspace
+            let next_work_children = self.tree.children_of(next_work_ix);
+            if cfg!(debug_assertions) {
+                assert!(next_work_children.len() == 1,
+                        "Next workspace has multiple roots!");
+            }
+            let next_work_root_ix = next_work_children[0];
+
+            // Move the container
+            info!("Moving container {:?} to workspace {}",
+                self.get_active_container(), name);
+            self.tree.move_node(active_ix, next_work_root_ix);
+
+            // Update the active container
+            if let Ok(parent_ix) = maybe_active_parent {
+                let ctype = self.tree.node_type(parent_ix).unwrap_or(ContainerType::Root);
+                if ctype == ContainerType::Container {
+                    self.focus_on_next_container(parent_ix);
+                } else {
+                    trace!("Send to container invalidated a NodeIndex: {:?} to {:?}",
+                    parent_ix, ctype);
+                }
+                if self.tree.can_remove_empty_parent(parent_ix) {
+                    self.remove_view_or_container(parent_ix);
+                }
+            }
+            else {
+                self.focus_on_next_container(curr_work_ix);
+            }
+
+            self.tree.set_family_visible(curr_work_ix, true);
+
+            self.normalize_container(active_ix);
+        }
+        let root_ix = self.tree.root_ix();
+        self.layout(root_ix);
+        self.validate();
+    }
+}

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -47,7 +47,7 @@ impl LayoutTree {
                         Some(new_active)
                     },
                     // else try and get the root container
-                    _ => self.tree.descendant_of_type(new_active, ContainerType::Container)
+                    _ => self.tree.descendant_of_type(new_active, ContainerType::Container).ok()
                 }
             });
         if maybe_active_ix.is_none() {
@@ -84,7 +84,7 @@ impl LayoutTree {
         self.tree.set_family_visible(workspace_ix, true);
         // Delete the old workspace if it has no views on it
         self.active_container = None;
-        if self.tree.descendant_of_type(old_worksp_ix, ContainerType::View).is_none() {
+        if self.tree.descendant_of_type(old_worksp_ix, ContainerType::View).is_err() {
             trace!("Removing workspace: {:?}", self.tree[old_worksp_ix].get_name()
                    .expect("Workspace had no name"));
             self.remove_container(old_worksp_ix);
@@ -107,7 +107,7 @@ impl LayoutTree {
             },
             _ => {
                 self.active_container = self.tree.descendant_of_type(active_ix, ContainerType::View)
-                    .or_else(|| self.tree.descendant_of_type(active_ix, ContainerType::Container));
+                    .or_else(|_| self.tree.descendant_of_type(active_ix, ContainerType::Container)).ok();
             }
         }
         self.focus_on_next_container(workspace_ix);

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -44,13 +44,13 @@ pub fn tile_switch() {
 
 pub fn split_vertical() {
     if let Ok(mut tree) = try_lock_tree() {
-        tree.0.toggle_active_layout(Layout::Vertical);
+        tree.0.toggle_active_layout(Layout::Vertical).ok();
     }
 }
 
 pub fn split_horizontal() {
     if let Ok(mut tree) = try_lock_tree() {
-        tree.0.toggle_active_layout(Layout::Horizontal);
+        tree.0.toggle_active_layout(Layout::Horizontal).ok();
     }
 }
 
@@ -193,8 +193,8 @@ impl Tree {
             view.set_geometry(ResizeEdge::empty(), fullscreen);
             return Ok(());
         }
-        tree.add_view(view.clone());
-        tree.normalize_view(view.clone());
+        try!(tree.add_view(view));
+        tree.normalize_view(view);
         tree.layout_active_of(ContainerType::Container);
         Ok(())
     }
@@ -249,7 +249,7 @@ impl Tree {
 
     /// Sets the view to be the new active container. Never fails
     pub fn set_active_view(&mut self, view: WlcView) -> CommandResult {
-        self.0.set_active_view(view.clone());
+        try!(self.0.set_active_view(view.clone()));
         view.focus();
         Ok(())
     }
@@ -284,7 +284,7 @@ impl Tree {
     }
 
     pub fn move_focus(&mut self, dir: Direction) -> CommandResult {
-        self.0.move_focus(dir);
+        try!(self.0.move_focus(dir));
         Ok(())
     }
 

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -34,7 +34,7 @@ pub fn remove_active() {
 
 pub fn tile_switch() {
     if let Ok(mut tree) = try_lock_tree() {
-        tree.0.toggle_active_horizontal();
+        tree.0.toggle_cardinal_tiling();
         tree.layout_active_of(ContainerType::Workspace)
             .unwrap_or_else(|_| {
                 warn!("Could not tile workspace");

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -67,7 +67,7 @@ impl InnerTree {
     /// Determines if the container at the node index is the root.
     /// Normally, this should only be true if the NodeIndex value is 1.
     pub fn is_root_container(&self, node_ix: NodeIndex) -> bool {
-        if let Some(parent_ix) = self.parent_of(node_ix) {
+        if let Ok(parent_ix) = self.parent_of(node_ix) {
             self.graph[parent_ix].get_type() == ContainerType::Workspace
         } else {
             false
@@ -198,8 +198,8 @@ impl InnerTree {
     /// be siblings of each other, otherwise this function will fail.
     pub fn swap_node_order(&mut self, child1_ix: NodeIndex,
                            child2_ix: NodeIndex) -> Result<(), GraphError> {
-        let parent1_ix = try!(self.parent_of(child1_ix).ok_or(GraphError::NoParent(child1_ix)));
-        let parent2_ix = try!(self.parent_of(child2_ix).ok_or(GraphError::NoParent(child2_ix)));
+        let parent1_ix = try!(self.parent_of(child1_ix));
+        let parent2_ix = try!(self.parent_of(child2_ix));
         if parent2_ix != parent1_ix {
             return Err(GraphError::NotSiblings(child1_ix, child2_ix))
         }
@@ -219,7 +219,7 @@ impl InnerTree {
     /// (which is always the same as the target node).
     pub fn move_into(&mut self, source: NodeIndex, target: NodeIndex)
                      -> Result<NodeIndex, GraphError> {
-        let source_parent = try!(self.parent_of(source).ok_or(GraphError::NoParent(source)));
+        let source_parent = try!(self.parent_of(source));
         let source_parent_edge = self.graph.find_edge(source_parent, source)
             .expect("Source node and it's parent were not linked");
         self.graph.remove_edge(source_parent_edge);
@@ -242,7 +242,7 @@ impl InnerTree {
                          -> Result<NodeIndex, GraphError> {
         trace!("Placing source {:?} at target {:?}. Shifting to {:?}",
                source, target, dir);
-        let target_parent = try!(self.parent_of(target).ok_or(GraphError::NoParent(target)));
+        let target_parent = try!(self.parent_of(target));
         let target_parent_edge = self.graph.find_edge(target_parent, target)
             .expect("Target node and it's parent were not linked");
         let target_weight = match dir {
@@ -260,7 +260,7 @@ impl InnerTree {
         let bigger_target_siblings: Vec<NodeIndex> = self.graph.edges_directed(target_parent, EdgeDirection::Outgoing)
             .filter(|&(_node_ix, sibling_weight)| *sibling_weight >= target_weight)
             .map(|(node_ix, _)| node_ix).collect();
-        let source_parent = try!(self.parent_of(source).ok_or(GraphError::NoParent(source)));
+        let source_parent = try!(self.parent_of(source));
         let source_parent_edge = self.graph.find_edge(source_parent, source)
             .expect("Source node and it's parent were not linked");
         for sibling_ix in bigger_target_siblings {
@@ -288,9 +288,9 @@ impl InnerTree {
     /// Returns the new parent of the source after the transformation, if no error occurred.
     pub fn add_to_end(&mut self, source: NodeIndex, target: NodeIndex, dir: ShiftDirection)
                       -> Result<NodeIndex, GraphError> {
-        let target_parent = try!(self.parent_of(target).ok_or(GraphError::NoParent(target)));
+        let target_parent = try!(self.parent_of(target));
         let siblings = self.children_of(target_parent);
-        let source_parent = try!(self.parent_of(source).ok_or(GraphError::NoParent(source)));
+        let source_parent = try!(self.parent_of(source));
         let source_parent_edge = self.graph.find_edge(source_parent, source)
             .expect("Source node and it's parent were not linked");
         match dir {
@@ -328,7 +328,7 @@ impl InnerTree {
     /// Detaches a node from the tree (causing there to be two trees).
     /// This should only be done temporarily.
     fn detach(&mut self, node_ix: NodeIndex) {
-        if let Some(parent_ix) = self.parent_of(node_ix) {
+        if let Ok(parent_ix) = self.parent_of(node_ix) {
             let edge = self.graph.find_edge(parent_ix, node_ix)
                 .expect("detatch: Node has parent but edge cannot be found!");
 
@@ -368,7 +368,7 @@ impl InnerTree {
             let last_id = last_container.get_id();
             self.id_map.insert(last_id, node_ix);
         }
-        if let Some(mut parent_ix) = maybe_parent_ix {
+        if let Ok(mut parent_ix) = maybe_parent_ix {
             if parent_ix == last_ix {
                 parent_ix = node_ix;
             }
@@ -435,11 +435,11 @@ impl InnerTree {
     }
 
     /// Gets the parent of a node, if the node exists
-    pub fn parent_of(&self, node_ix: NodeIndex) -> Option<NodeIndex> {
+    pub fn parent_of(&self, node_ix: NodeIndex) -> Result<NodeIndex, GraphError> {
         let mut neighbors = self.graph
             .neighbors_directed(node_ix, EdgeDirection::Incoming);
+        let result = neighbors.next().ok_or(GraphError::NoParent(node_ix));
         if cfg!(debug_assertions) {
-            let result = neighbors.next();
             if neighbors.next().is_some() {
                 error!("{:?}", self);
                 panic!("parent_of: node has multiple parents!")
@@ -447,7 +447,7 @@ impl InnerTree {
             result
         }
         else {
-            neighbors.next()
+            result
         }
     }
 
@@ -503,7 +503,7 @@ impl InnerTree {
     pub fn ancestor_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Option<NodeIndex> {
         let mut curr_ix = node_ix;
-        while let Some(parent_ix) = self.parent_of(curr_ix) {
+        while let Ok(parent_ix) = self.parent_of(curr_ix) {
             let parent = self.graph.node_weight(parent_ix)
                 .expect("ancestor_of_type: parent_of invalid");
             if parent.get_type() == container_type {
@@ -617,7 +617,7 @@ impl InnerTree {
     /// If a divergent path is detected, that edge is deactivated in favor of
     /// the one that leads to this node.
     pub fn set_ancestor_paths_active(&mut self, mut node_ix: NodeIndex) {
-        while let Some(parent_ix) = self.parent_of(node_ix) {
+        while let Ok(parent_ix) = self.parent_of(node_ix) {
             for child_ix in self.children_of(parent_ix) {
                 let edge_ix = self.graph.find_edge(parent_ix, child_ix)
                     .expect("Could not get edge index between parent and child");

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -97,6 +97,22 @@ impl InnerTree {
         result
     }
 
+    /// Follows the active path beneath the node until it ends.
+    /// Returns the last node in the chain.
+    pub fn follow_path(&self, node_ix: NodeIndex) -> NodeIndex {
+        let mut next_ix = Some(node_ix);
+        while let Some(cur_ix) = next_ix {
+            let maybe_edge = self.graph.edges_directed(cur_ix, EdgeDirection::Outgoing)
+                .find(|&(_, weight): &(_, &Path)| weight.active);
+            if let Some(edge) = maybe_edge {
+                next_ix = Some(edge.0);
+            } else {
+                return cur_ix
+            }
+        }
+        node_ix
+    }
+
     /// Gets the weight of a possible edge between two notes
     pub fn get_edge_weight_between(&self, parent_ix: NodeIndex,
                                    child_ix: NodeIndex) -> Option<&Path> {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -39,7 +39,7 @@ pub enum TreeError {
     InvalidOperationOnRootContainer(Uuid),
     /// There was an error in the graph, an invariant of one of the
     /// functions were not held, so this might be an issue in the Tree.
-    PetGraphError(GraphError),
+    PetGraph(GraphError),
     /// An error occured while trying to focus on a container
     Focus(FocusError)
 }
@@ -340,7 +340,7 @@ impl LayoutTree {
     /// Will attempt to move the container at the UUID in the given direction.
     pub fn move_container(&mut self, uuid: Uuid, direction: Direction) -> CommandResult {
         let node_ix = try!(self.tree.lookup_id(uuid).ok_or(TreeError::NodeNotFound(uuid)));
-        let old_parent_ix = try!(self.tree.parent_of(node_ix).map_err(|err| TreeError::PetGraphError(err)));
+        let old_parent_ix = try!(self.tree.parent_of(node_ix).map_err(|err| TreeError::PetGraph(err)));
         try!(self.move_recurse(node_ix, None, direction));
         if self.tree.can_remove_empty_parent(old_parent_ix) {
             self.remove_container(old_parent_ix);

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -809,7 +809,7 @@ pub mod tests {
             },
             _ => unreachable!()
         }
-        tree.toggle_active_horizontal();
+        tree.toggle_cardinal_tiling();
         let parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
         match tree.tree[parent] {
             Container::Container { ref layout, .. } => {
@@ -819,7 +819,7 @@ pub mod tests {
             _ => unreachable!()
         }
         // and back again
-        tree.toggle_active_horizontal();
+        tree.toggle_cardinal_tiling();
         let parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
         match tree.tree[parent] {
             Container::Container { ref layout, .. } => {

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -107,17 +107,6 @@ impl LayoutTree {
         self.active_container.and_then(move |ix| self.tree.get_mut(ix))
     }
 
-    /// Gets the parent of the active container
-    #[cfg(test)]
-    fn get_active_parent(&self) -> Option<&Container> {
-        if let Some(container_ix) = self.active_container {
-            if let Ok(parent_ix) = self.tree.parent_of(container_ix) {
-                return Some(&self.tree[parent_ix]);
-            }
-        }
-        return None
-    }
-
     /// Gets the index of the currently active container with the given type.
     /// Starts at the active container, moves up until either a container with
     /// that type is found or the root node is hit
@@ -742,7 +731,6 @@ pub mod tests {
         let mut tree = basic_tree();
         tree.active_container = None;
         assert_eq!(tree.get_active_container(), None);
-        assert_eq!(tree.get_active_parent(), None);
         assert_eq!(tree.active_ix_of(ContainerType::View), None);
         assert_eq!(tree.active_ix_of(ContainerType::Container), None);
         assert_eq!(tree.active_ix_of(ContainerType::Workspace), None);
@@ -1002,7 +990,8 @@ pub mod tests {
     fn tiling_toggle_key() {
         let mut tree = basic_tree();
         // active container is the first view, so it should just change it's root.
-        match *tree.get_active_parent().unwrap() {
+        let parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        match tree.tree[parent] {
             Container::Container { ref layout, .. } => {
                 // default is horizontal
                 assert_eq!(*layout, Layout::Horizontal)
@@ -1010,7 +999,8 @@ pub mod tests {
             _ => unreachable!()
         }
         tree.toggle_active_horizontal();
-        match *tree.get_active_parent().unwrap() {
+        let parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        match tree.tree[parent] {
             Container::Container { ref layout, .. } => {
                 // default is horizontal
                 assert_eq!(*layout, Layout::Vertical)
@@ -1019,7 +1009,8 @@ pub mod tests {
         }
         // and back again
         tree.toggle_active_horizontal();
-        match *tree.get_active_parent().unwrap() {
+        let parent = tree.tree.parent_of(tree.active_container.unwrap()).unwrap();
+        match tree.tree[parent] {
             Container::Container { ref layout, .. } => {
                 // default is horizontal
                 assert_eq!(*layout, Layout::Horizontal)

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -842,7 +842,7 @@ pub mod tests {
         assert_eq!(tree.active_ix_of(ContainerType::Workspace), None);
         assert!(tree.active_ix_of(ContainerType::Output).is_none());
         assert!(tree.active_ix_of(ContainerType::Root).is_none());
-        tree.set_active_view(WlcView::root());
+        tree.set_active_view(WlcView::root()).unwrap();
         let view_ix = tree.tree.descendant_with_handle(tree.tree.root_ix(), &WlcView::root()).unwrap();
         assert_eq!(tree.active_container, Some(view_ix));
         tree.unset_active_container();

--- a/src/lua/init_path.rs
+++ b/src/lua/init_path.rs
@@ -1,4 +1,5 @@
 //! Contains methods for initializing the lua config
+#![allow(dead_code)]
 
 use std::fs::{OpenOptions, File};
 use std::env;


### PR DESCRIPTION
* Added error propagation (instead of bare panics). This will allow us to do later fancy thing, e.g like having a way to recover from strange errors with a soft reset.
* Moved more things out of tree.rs
  + Added workspace to actions
* More concise error names.