### PR TITLE
(Not finished) petgraph 0.3 + StableGraph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.3"
 env_logger = "0.3"
 hlua = "0.1"
 bitflags = "0.6"
-petgraph = "0.2"
+petgraph = { version = "0.3.1" }
 rustc-serialize = "0.3"
 json_macro = "0.1"
 nix = "0.6"


### PR DESCRIPTION
Since I did this, I wanted to share to not have the work duplicated.

There's a failing test left in here, it's expecting an index to have shifted. I don't know what more code might be depending on indices to shift.

The code has a good handle on the issues of using `Graph`, so it's not really a problem that needs fixing (but the shorter .edge() calls in the first commit are nice anyway.)

Since you mentioned a map-based approach you could use something similar to petgraph::GraphMap. Just like StableGraph, those are not the main things of the library and are not as well tested or yet developed as `Graph`.

The roadmap includes rewriting `GraphMap` once more, so that it still uses `N` (Uuids in your hypothetical case) for node keys, but graph indices internally.
