### PR TITLE
Hotfix init file loading code

### DIFF
--- a/src/lua/init_path.rs
+++ b/src/lua/init_path.rs
@@ -29,33 +29,38 @@ pub fn get_config() -> (bool, Result<File, &'static str>) {
 fn get_config_file() -> Result<File, &'static str> {
     let home_var = env::var("HOME").expect("HOME environment variable not defined!");
     let home = home_var.as_str();
+
     if let Ok(path_env) = env::var("WAY_COOLER_INIT_FILE") {
+        info!("Found $WAY_COOLER_INIT_FILE to be defined, will look for the init file there.")
         if let Ok(file) = read_file(Path::new(&path_env)) {
             info!("Reading init file from $WAY_COOLER_INIT_FILE: {}",
                   path_env.as_str().replace(home, "~"));
             return Ok(file)
         }
-        warn!("Looking for init file: $WAY_COOLER_INIT_FILE={}, was not a valid path to a config file.",
+        warn!("Did not find an init file at $WAY_COOLER_INIT_FILE! It points to {}",
               path_env.as_str().replace(home, "~"));
     }
 
     if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
         let init_file_path = Path::new(&xdg).join("way-cooler").join(INIT_FILE);
+        info!("Found $XDG_CONFIG_DIR to be defined, will look for the init file at $XDG_CONFIG_DIR/way-cooler/init.lua");
         if let Ok(file) = read_file(&init_file_path) {
-            info!("Reading init file from $XDG_CONFIG_HOME");
+            info!("Reading init file from $XDG_CONFIG_HOME/way-cooler/init.lua");
             return Ok(file)
         }
         else {
-            warn!("Looking for init file: nothing at $XDG_CONFIG_HOME, no file {}.",
+            warn!("Did not find an init file inside $XDG_CONFIG_HOME, no file {}.",
                   &init_file_path.to_string_lossy().replace(home, "~"));
         }
     }
     let dot_config = Path::new(home).join(".config").join("way-cooler").join(INIT_FILE);
 
-    trace!("Looking for init file at {:?}", dot_config.to_string_lossy().replace(home, "~"));
+    trace!("Looking for init file at ~/.config/way-cooler/init.lua");
     if let Ok(file) = read_file(&dot_config) {
-        info!("Reading init file from {:?}", &dot_config.to_string_lossy().replace(home, "~"));
+        info!("Reading init file from ~/.config/way-cooler/init.lua");
         return Ok(file)
+    } else {
+        warn!("No init file found in ~/.config, will default to /etc as a last resort.");
     }
 
     let etc_config = Path::new(INIT_FILE_FALLBACK_PATH).join(INIT_FILE);
@@ -64,6 +69,19 @@ fn get_config_file() -> Result<File, &'static str> {
         info!("Reading init file from fallback {:?}", &etc_config);
         return Ok(file)
     }
+
+    warn!("way-cooler was unable to find an init file. \
+           This is currently required to use way-cooler.");
+    warn!("Our default init.lua is available on GitHub, \
+           it is included with the source.");
+    warn!("You may place it in ~/.config/way-cooler/init.lua, \
+           or a similar folder if you use $XDG_CONFIG_HOME, or /etc/way-cooler.");
+    warn!("You may also use the environment variable $WAY_COOLER_INIT_FILE to point \
+           directly to the file of your choice.");
+
+    info!("The init file will be included with way-cooler in the next release. If you \
+           do not have one or do not wish to customize we will always have the default \
+           to fall back on.");
 
     return Err("Could not find an init file in any path!")
 }

--- a/src/lua/init_path.rs
+++ b/src/lua/init_path.rs
@@ -31,7 +31,7 @@ fn get_config_file() -> Result<File, &'static str> {
     let home = home_var.as_str();
 
     if let Ok(path_env) = env::var("WAY_COOLER_INIT_FILE") {
-        info!("Found $WAY_COOLER_INIT_FILE to be defined, will look for the init file there.")
+        info!("Found $WAY_COOLER_INIT_FILE to be defined, will look for the init file there.");
         if let Ok(file) = read_file(Path::new(&path_env)) {
             info!("Reading init file from $WAY_COOLER_INIT_FILE: {}",
                   path_env.as_str().replace(home, "~"));

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -92,13 +92,13 @@ pub fn send(query: LuaQuery) -> Result<Receiver<LuaResponse>, LuaSendError> {
 
 /// Initialize the Lua thread.
 pub fn init() {
-    trace!("Initializing...");
+    debug!("Initializing...");
     let (tx, receiver) = channel();
     *SENDER.lock().expect(ERR_LOCK_SENDER) = Some(tx);
     let mut lua = Lua::new();
     debug!("Loading Lua libraries...");
     lua.openlibs();
-    trace!("Loading way-cooler libraries...");
+    debug!("Loading way-cooler libraries...");
     rust_interop::register_libraries(&mut lua);
 
     let (use_config, maybe_init_file) = init_path::get_config();
@@ -107,8 +107,8 @@ pub fn init() {
             Ok(init_file) => {
                 // TODO defaults here are important
                 let _: () = lua.execute_from_reader(init_file)
-                    .expect("Unable to load config file");
-                debug!("Read config file");
+                    .expect("Unable to load init file");
+                debug!("Read init.lua successfully");
             }
             Err(reason) => {
                 panic!("Unable to load init file: {}", reason)
@@ -116,7 +116,7 @@ pub fn init() {
         }
     }
     else {
-        trace!("Skipping config search");
+        info!("Skipping config search");
     }
 
     // Only ready after loading libs


### PR DESCRIPTION
* Error messages replace `$HOME` with `~` (nicer replacements later)
* Fix using the wrong path for `$XDG_CONFIG_DIR`
* Fix not using `$WAY_COOLER_INIT_FILE` (breaking change)
* Warnings when looking for the init file are improved