### PR TITLE
Added clarifying comment to README about video

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Way Cooler is a customizable tiling window manager written in [Rust][] for [Wayl
 # Development
 
 Way Cooler is currently in alpha. The core features have been added and it is in a usable state, but more work is needed to
-make it user friendly.
+make it user friendly. Here's an example where we run Way Cooler within i3. Everything within the wlc-x11 window is Way Cooler:
 
 
 [![way-cooler demonstration](http://i.imgur.com/UiJbpiv.png)](https://www.youtube.com/watch?v=I2FO5dnOBb0)


### PR DESCRIPTION
As @AdrianSchurz pointed out, the video is a little confusing about what is actually being shown. When we have better features to show off the video will be replaced, but until then I have added some clarifying sentences explaining what to focus on in the video.