### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "way-cooler"
 version = "0.3.2"
 dependencies = [
- "bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dummy-rustwlc 0.5.1 (git+https://github.com/SnirkImmington/dummy-rustwlc.git)",
  "env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12,7 +12,7 @@ dependencies = [
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "petgraph 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustwlc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -199,11 +199,17 @@ version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ordermap"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "petgraph"
-version = "0.2.7"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fixedbitset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -392,7 +398,7 @@ dependencies = [
 "checksum dtoa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0dd841b58510c9618291ffa448da2e4e0f699d984d436122372f446dae62263d"
 "checksum dummy-rustwlc 0.5.1 (git+https://github.com/SnirkImmington/dummy-rustwlc.git)" = "<none>"
 "checksum env_logger 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82dcb9ceed3868a03b335657b85a159736c961900f7e7747d3b0b97b9ccb5ccb"
-"checksum fixedbitset 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c59882225c22dfcd2db6f0fce45dabe334e64ffa5efacb785b7ffb5af690cc6f"
+"checksum fixedbitset 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3c33fc4c00db33f5174eb98aea809c4c007db0b71351d810a7e094ea3b64d"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum hlua 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bbfb8d2d13ce8251927e8a28373efb11789a17a38e58a07bb1fd1beb28290a3a"
@@ -408,7 +414,8 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum nix 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7bb1da2be7da3cbffda73fc681d509ffd9e665af478d2bee1907cee0bc64b2"
 "checksum num-traits 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "8359ea48994f253fa958b5b90b013728b06f54872e5a58bce39540fcdd0f2527"
-"checksum petgraph 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b74ca8301bb7054c688ac54e2ebad8decb402580f192040359db7fc36c0b4e04"
+"checksum ordermap 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0afbab4269d3d9411ce03b5bf341d4176f7419a1de1e606b75f076f6d6130e1"
+"checksum petgraph 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f4dff15ddd0c530e9dd440266e30a34b4154fbc447ed5215a98118dc45568dea"
 "checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
 "checksum rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2791d88c6defac799c3f20d74f094ca33b9332612d9aef9078519c82e4fe04a5"
 "checksum regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)" = "56b7ee9f764ecf412c6e2fff779bca4b22980517ae335a21aeaf4e32625a5df2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ lazy_static = "0.2"
 log = "0.3"
 env_logger = "0.3"
 hlua = "0.1"
-bitflags = "0.6"
-petgraph = "0.2"
+bitflags = "0.7"
+petgraph = "0.3"
 rustc-serialize = "0.3"
 json_macro = "0.1"
 nix = "0.6"
@@ -24,7 +24,7 @@ wayland-sys = { version = "^0.6.0", features = ["client", "dlopen"] }
 wayland-client = { version = "^0.6.0", features = ["cursor", "dlopen"] }
 tempfile = "2.1"
 byteorder = ">= 0.3, < 0.6"
-getopts = "^0.2"
+getopts = "0.2"
 
 [dev-dependencies]
 dummy-rustwlc = { git = "https://github.com/SnirkImmington/dummy-rustwlc.git"}


### PR DESCRIPTION
Update direct dependencies `bitflags = 0.7` and `petgraph = 0.3` in anticipation of 0.3.3.
`petgraph` is actually at `0.4` right now, but since that introduces backwards-breaking changes we can skip it for now.