### PR TITLE
Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ notifications:
     on_success: :change
     on_failure: :change
   email: false
-# load travis-cargo
+# install travis-cargo
 before_script:
   - |
       git clone https://github.com/Timidger/travis-cargo
@@ -30,7 +30,11 @@ script:
   - cargo test --verbose
 
 after_success:
-  # measure code coverage and upload to coveralls.io (the verify
-  # argument mitigates kcov crashes due to malformed debuginfo, at the
-  # cost of some speed <https://github.com/huonw/travis-cargo/issues/12>)
+  # Test and upload coverage to coveralls
+  # Justification of excluded files:
+  # main.rs: just initialization of logging, sigkill handler, and initializing lazy static objects. (Arg parsing should be moved into a different module and tested)
+  # mod.rs: although at the moment we have too much code in various mod.rs's these are not really testable either way
+  # tests.rs: should not be running on our tests themselves
+  # wayland_client_api.rs: we really don't have a good way of testing any of this. At the moment it's simple enough that if it didn't work it would be obvious in user testing.
+  # callbacks.rs: we don't have any integration tests for callbacks right now. They'd need to deal with the lazy statics that the other components of the program live in.
   - travis-cargo coveralls --no-sudo --verify --exclude-pattern="main.rs,mod.rs,tests.rs,wayland_client_api.rs,callbacks.rs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ install:
   - pip install --user -e ./travis-cargo
   # install dependencies for ci.py
   - pip install --user docopt
-  - cargo install cargo-check
 
 script:
   # check integrity of Lua files in /lib/lua/

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   # run tests
   - cargo test --verbose
   # run tag checks
-  - ci.py travis-check
+  - python $TRAVIS_BUILD_DIR/ci.py travis-check
 
 after_success:
   # Test and upload coverage to coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_deploy:
   - ci.py prepare-deploy
 deploy:
   provider: releases
-  skip_cleanup: false # We can skip cleanup as we recompile with --release
+  skip_cleanup: false # We do not need to skip cleanup as we recompile with --release
   on:
     tags: true
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: rust
+language: 
+  - rust
+  - lua
 rust:
   - stable
 cache: cargo
@@ -25,9 +27,7 @@ before_script:
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)
 script:
-  - echo "Checking Lua libs integrity"
-  - find -X lib/lua -type f -name "*.lua" | xargs luac -p
-  - echo "Checking init.lua integrity"
+  - find lib/lua -type f -name "*.lua" | xargs luac -p
   - luac -p config/init.lua
   - cargo check
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - stable
+ sudo: false
 
 cache:
   - cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,5 +70,6 @@ deploy:
     secure: "i+7X7qZgq5gwWbi/KBoL03rBTJam2ayJUxuTUGnQNwOEUc1KaDintZG/j6bp2DqFfodBx0oq/nvZi+mIAzbpQHlaDCav+GC0S3o2k10CAPlcg844IZVB22J/WbUjFfkpAWz0Mbs6U7cjCeAPAdYTbcJy5haduKm9FKOat87bBrNIdPZno3j7RDd1ne3+gsbEp0W9788jqX99vV7CWtV0hT5w1yT+COg8YdvCowOLh3mS/y43LZlmyqNFqJpF/tMnBWI9qDlhyCCzmsVb+xq9tjX4XQAgZJI6Y0uP8JoityqG1OpCAfgSpS99+0iy+lSGpALDfKAk04lIRMWublnMSXSqcHRupxF6mvlzer9V4XV1emgDn1rtnIkQiRryuA180mTVpHjGg+Ockl/wjOo4FJGKlDmQn7oT6EMDfY62md2tYbsB2MmJNlFXiQCinNFmjpTJuUbHwXmF4FArq4B8AmoFwY1I7I8x6eHKqLEZOxgm9EgtHC9+dwbRSY7t6X7AiHYv7LsDIjEO70oG7j/nuoZgBZZvMjOWlm7EKUjrcxXVLUZK9f9P/6Pc7r+OQr4jaRRclCtZPsPGPu/EjNfeQ0+PpZdByzT9k1y4loAqZPtP0ANBp7flKsPNWXaMSNsb/Hu4zolDDyeU5eL3VHyrDk1wi9nmFTOnrCl8W++7Fi4="
   file:
     - "way-cooler_linux_x86_64"
+    - "config/init.lua"
 after_deploy:
   - cargo publish --token $CARGO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: rust
+`language: rust
 rust:
   - stable
 cache: cargo
@@ -20,11 +20,11 @@ notifications:
   email: false
 # install travis-cargo
 before_script:
-  - |
-      git clone https://github.com/Timidger/travis-cargo
-      (cd travis-cargo;
-      pip install -e . --user &&
-      export PATH=$HOME/.local/bin:$PATH)
+  - git clone https://github.com/Timidger/travis-cargo
+  - export PATH=$HOME/.local/bin:$PATH
+  - (cd travis-cargo; pip install -e . --user)
+  - pip install --user docopt
+  - pip install --user semver
 script:
   - for file in $( find lib/lua -type f -name "*.lua" ); do echo Checking $file; luac -p $file; done
   - luac -p config/init.lua

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 rust:
   - stable
- sudo: false
+sudo: false
 
 cache:
   - cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_script:
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)
 script:
-  - cargo install cargo-check
   - cargo check
   - cargo test --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ before_script:
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)
 script:
+  - echo "Checking Lua libs integrity"
+  - find -X lib/lua -type f -name "*.lua" | xargs luac -p
+  - echo "Checking init.lua integrity"
+  - luac -p config/init.lua
   - cargo check
   - cargo test --verbose
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ deploy:
   on:
     tags: true
   api_key:
+    # GitHub token
     secure: "i+7X7qZgq5gwWbi/KBoL03rBTJam2ayJUxuTUGnQNwOEUc1KaDintZG/j6bp2DqFfodBx0oq/nvZi+mIAzbpQHlaDCav+GC0S3o2k10CAPlcg844IZVB22J/WbUjFfkpAWz0Mbs6U7cjCeAPAdYTbcJy5haduKm9FKOat87bBrNIdPZno3j7RDd1ne3+gsbEp0W9788jqX99vV7CWtV0hT5w1yT+COg8YdvCowOLh3mS/y43LZlmyqNFqJpF/tMnBWI9qDlhyCCzmsVb+xq9tjX4XQAgZJI6Y0uP8JoityqG1OpCAfgSpS99+0iy+lSGpALDfKAk04lIRMWublnMSXSqcHRupxF6mvlzer9V4XV1emgDn1rtnIkQiRryuA180mTVpHjGg+Ockl/wjOo4FJGKlDmQn7oT6EMDfY62md2tYbsB2MmJNlFXiQCinNFmjpTJuUbHwXmF4FArq4B8AmoFwY1I7I8x6eHKqLEZOxgm9EgtHC9+dwbRSY7t6X7AiHYv7LsDIjEO70oG7j/nuoZgBZZvMjOWlm7EKUjrcxXVLUZK9f9P/6Pc7r+OQr4jaRRclCtZPsPGPu/EjNfeQ0+PpZdByzT9k1y4loAqZPtP0ANBp7flKsPNWXaMSNsb/Hu4zolDDyeU5eL3VHyrDk1wi9nmFTOnrCl8W++7Fi4="
   file:
     - "way-cooler_linux_x86_64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_script:
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)
 script:
+  - cargo install cargo-check
+  - cargo check
   - cargo test --verbose
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: rust
 rust:
   - stable
-depth: 3 # We don't need to clone with depth 50
 
 sudo: false
+git:
+  depth: 3 # We don't need to clone with depth 50
 
 cache:
   - cargo
@@ -27,7 +28,7 @@ notifications:
   email: false
 
 before_install:
-  - git clone --depth=1 https://github.com/Timidger/travis-cargo
+  - git clone --depth=3 https://github.com/Timidger/travis-cargo
   - export PATH=$HOME/.local/bin:$PATH
 
 install:
@@ -59,7 +60,6 @@ after_success:
   - travis-cargo coveralls --no-sudo --verify --exclude-pattern="main.rs,mod.rs,tests.rs,wayland_client_api.rs,callbacks.rs"
 
 before_deploy:
-  - export WAY_COOLER_STATIC_LINK=true
   - ci.py prepare-deploy
 deploy:
   provider: releases
@@ -70,4 +70,5 @@ deploy:
     secure: "i+7X7qZgq5gwWbi/KBoL03rBTJam2ayJUxuTUGnQNwOEUc1KaDintZG/j6bp2DqFfodBx0oq/nvZi+mIAzbpQHlaDCav+GC0S3o2k10CAPlcg844IZVB22J/WbUjFfkpAWz0Mbs6U7cjCeAPAdYTbcJy5haduKm9FKOat87bBrNIdPZno3j7RDd1ne3+gsbEp0W9788jqX99vV7CWtV0hT5w1yT+COg8YdvCowOLh3mS/y43LZlmyqNFqJpF/tMnBWI9qDlhyCCzmsVb+xq9tjX4XQAgZJI6Y0uP8JoityqG1OpCAfgSpS99+0iy+lSGpALDfKAk04lIRMWublnMSXSqcHRupxF6mvlzer9V4XV1emgDn1rtnIkQiRryuA180mTVpHjGg+Ockl/wjOo4FJGKlDmQn7oT6EMDfY62md2tYbsB2MmJNlFXiQCinNFmjpTJuUbHwXmF4FArq4B8AmoFwY1I7I8x6eHKqLEZOxgm9EgtHC9+dwbRSY7t6X7AiHYv7LsDIjEO70oG7j/nuoZgBZZvMjOWlm7EKUjrcxXVLUZK9f9P/6Pc7r+OQr4jaRRclCtZPsPGPu/EjNfeQ0+PpZdByzT9k1y4loAqZPtP0ANBp7flKsPNWXaMSNsb/Hu4zolDDyeU5eL3VHyrDk1wi9nmFTOnrCl8W++7Fi4="
   file:
     - "way-cooler_linux_x86_64"
-    - "$TRAVIS_BUILD_DIR/config/init.lua"
+after_deploy:
+  - cargo publish --token $CARGO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ install:
   - pip install --user -e ./travis-cargo
   # install dependencies for ci.py
   - pip install --user docopt
+  # Sometimes cargo check doesn't exist?
+  - cargo install --force cargo-check
 
 script:
   # check integrity of Lua files in /lib/lua/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-`language: rust
+language: rust
 rust:
   - stable
 cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-language: 
-  - rust
-  - lua
+language: rust
 rust:
   - stable
 cache: cargo
@@ -12,6 +10,7 @@ addons:
       - libelf-dev
       - libdw-dev
       - binutils-dev
+      - lua5.2
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: rust
 rust:
   - stable
+depth: 3 # We don't need to clone with depth 50
+
 sudo: false
 
 cache:
@@ -23,18 +25,19 @@ notifications:
   slack:
     rooms:
       - way-cooler:W2vOSvJvgxGi7EiGkZCtvlB6#way-cooler
-    on_success: :change
-    on_failure: :change
+    on_success: change
+    on_failure: change
   email: false
 
-before_script:
-  # install travis-cargo
-  - git clone https://github.com/Timidger/travis-cargo
+before_install:
+  - git clone --depth=1 https://github.com/Timidger/travis-cargo
   - export PATH=$HOME/.local/bin:$PATH
-  - (cd travis-cargo; pip install -e . --user)
+
+install:
+  # install travis-cargo
+  - pip install --user -e ./travis-cargo
   # install dependencies for ci.py
   - pip install --user docopt
-  - pip install --user semver
   - cargo install cargo-check
 
 script:
@@ -43,7 +46,7 @@ script:
   # check integrity of init file
   - luac -p config/init.lua
   # Make sure no-test builds
-  - cargo check
+  - cargo check --verbose
   # run tests
   - cargo test --verbose
   # run tag checks
@@ -60,6 +63,8 @@ after_success:
   - travis-cargo coveralls --no-sudo --verify --exclude-pattern="main.rs,mod.rs,tests.rs,wayland_client_api.rs,callbacks.rs"
 
 before_deploy:
+  - export WAY_COOLER_STATIC_LINK=true
+  - cargo build --release
   - ci.py prepare-deploy
 deploy:
   provider: releases
@@ -69,4 +74,5 @@ deploy:
   api_key:
     secure: "i+7X7qZgq5gwWbi/KBoL03rBTJam2ayJUxuTUGnQNwOEUc1KaDintZG/j6bp2DqFfodBx0oq/nvZi+mIAzbpQHlaDCav+GC0S3o2k10CAPlcg844IZVB22J/WbUjFfkpAWz0Mbs6U7cjCeAPAdYTbcJy5haduKm9FKOat87bBrNIdPZno3j7RDd1ne3+gsbEp0W9788jqX99vV7CWtV0hT5w1yT+COg8YdvCowOLh3mS/y43LZlmyqNFqJpF/tMnBWI9qDlhyCCzmsVb+xq9tjX4XQAgZJI6Y0uP8JoityqG1OpCAfgSpS99+0iy+lSGpALDfKAk04lIRMWublnMSXSqcHRupxF6mvlzer9V4XV1emgDn1rtnIkQiRryuA180mTVpHjGg+Ockl/wjOo4FJGKlDmQn7oT6EMDfY62md2tYbsB2MmJNlFXiQCinNFmjpTJuUbHwXmF4FArq4B8AmoFwY1I7I8x6eHKqLEZOxgm9EgtHC9+dwbRSY7t6X7AiHYv7LsDIjEO70oG7j/nuoZgBZZvMjOWlm7EKUjrcxXVLUZK9f9P/6Pc7r+OQr4jaRRclCtZPsPGPu/EjNfeQ0+PpZdByzT9k1y4loAqZPtP0ANBp7flKsPNWXaMSNsb/Hu4zolDDyeU5eL3VHyrDk1wi9nmFTOnrCl8W++7Fi4="
   file:
-    - "$TRAIVS_BUILD_DIR/way-cooler_linux_x86_64"
+    - "way-cooler_linux_x86_64"
+    - "$TRAVIS_BUILD_DIR/config/init.lua"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   - pip
   - directories:
       # kcov
-      - $HOME/.local/bin
+      - $TRAVIS_BUILD_DIR/kcov
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: rust
 rust:
   - stable
-cache: cargo
-# necessary for `travis-cargo coveralls --no-sudo`
+
+cache:
+  - cargo
+  - pip
+  - directories:
+      # kcov
+      - $HOME/.local/bin
+before_cache:
+  # Try to clear out some files we don't need to cache.
+  - rm $HOME/build/Immington-Industries/way-cooler/target/debug/deps -rf
+  - rm $HOME/build/Immington-Industries/way-cooler/target/debug/way-cooler
+  - rm $HOME/build/Immington-Industries/way-cooler/target/debug/.fingerprint -rf
+
 addons:
   apt:
     packages:
@@ -11,6 +22,7 @@ addons:
       - libdw-dev
       - binutils-dev
       - lua5.2
+
 notifications:
   slack:
     rooms:
@@ -18,17 +30,24 @@ notifications:
     on_success: :change
     on_failure: :change
   email: false
-# install travis-cargo
+
 before_script:
+  # install travis-cargo
   - git clone https://github.com/Timidger/travis-cargo
   - export PATH=$HOME/.local/bin:$PATH
   - (cd travis-cargo; pip install -e . --user)
+  # install dependencies for ci.py
   - pip install --user docopt
   - pip install --user semver
+
 script:
+  # check integrity of Lua files in /lib/lua/
   - for file in $( find lib/lua -type f -name "*.lua" ); do echo Checking $file; luac -p $file; done
+  # check integrity of init file
   - luac -p config/init.lua
+  # Make sure no-test builds
   - cargo check
+  # run tests
   - cargo test --verbose
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ sudo: false
 cache:
   - cargo
   - pip
-  - directories:
-      # kcov
-      - $TRAVIS_BUILD_DIR/kcov
 
 addons:
   apt:
@@ -63,7 +60,6 @@ after_success:
 
 before_deploy:
   - export WAY_COOLER_STATIC_LINK=true
-  - cargo build --release
   - ci.py prepare-deploy
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
   # install dependencies for ci.py
   - pip install --user docopt
   - pip install --user semver
+  - cargo install cargo-check
 
 script:
   # check integrity of Lua files in /lib/lua/
@@ -57,3 +58,15 @@ after_success:
   # wayland_client_api.rs: we really don't have a good way of testing any of this. At the moment it's simple enough that if it didn't work it would be obvious in user testing.
   # callbacks.rs: we don't have any integration tests for callbacks right now. They'd need to deal with the lazy statics that the other components of the program live in.
   - travis-cargo coveralls --no-sudo --verify --exclude-pattern="main.rs,mod.rs,tests.rs,wayland_client_api.rs,callbacks.rs"
+
+before_deploy:
+  - ci.py prepare-deploy
+deploy:
+  provider: releases
+  skip_cleanup: true # We can skip cleanup as we recompile with --release
+  on:
+    tags: true
+  api_key:
+    secure: "i+7X7qZgq5gwWbi/KBoL03rBTJam2ayJUxuTUGnQNwOEUc1KaDintZG/j6bp2DqFfodBx0oq/nvZi+mIAzbpQHlaDCav+GC0S3o2k10CAPlcg844IZVB22J/WbUjFfkpAWz0Mbs6U7cjCeAPAdYTbcJy5haduKm9FKOat87bBrNIdPZno3j7RDd1ne3+gsbEp0W9788jqX99vV7CWtV0hT5w1yT+COg8YdvCowOLh3mS/y43LZlmyqNFqJpF/tMnBWI9qDlhyCCzmsVb+xq9tjX4XQAgZJI6Y0uP8JoityqG1OpCAfgSpS99+0iy+lSGpALDfKAk04lIRMWublnMSXSqcHRupxF6mvlzer9V4XV1emgDn1rtnIkQiRryuA180mTVpHjGg+Ockl/wjOo4FJGKlDmQn7oT6EMDfY62md2tYbsB2MmJNlFXiQCinNFmjpTJuUbHwXmF4FArq4B8AmoFwY1I7I8x6eHKqLEZOxgm9EgtHC9+dwbRSY7t6X7AiHYv7LsDIjEO70oG7j/nuoZgBZZvMjOWlm7EKUjrcxXVLUZK9f9P/6Pc7r+OQr4jaRRclCtZPsPGPu/EjNfeQ0+PpZdByzT9k1y4loAqZPtP0ANBp7flKsPNWXaMSNsb/Hu4zolDDyeU5eL3VHyrDk1wi9nmFTOnrCl8W++7Fi4="
+  file:
+    - "$TRAIVS_BUILD_DIR/way-cooler_linux_x86_64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_deploy:
   - ci.py prepare-deploy
 deploy:
   provider: releases
-  skip_cleanup: true # We can skip cleanup as we recompile with --release
+  skip_cleanup: false # We can skip cleanup as we recompile with --release
   on:
     tags: true
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ script:
   - cargo check
   # run tests
   - cargo test --verbose
+  # run tag checks
+  - ci.py travis-check
 
 after_success:
   # Test and upload coverage to coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ cache:
   - directories:
       # kcov
       - $HOME/.local/bin
-before_cache:
-  # Try to clear out some files we don't need to cache.
-  - rm $HOME/build/Immington-Industries/way-cooler/target/debug/deps -rf
-  - rm $HOME/build/Immington-Industries/way-cooler/target/debug/way-cooler
-  - rm $HOME/build/Immington-Industries/way-cooler/target/debug/.fingerprint -rf
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
       pip install -e . --user &&
       export PATH=$HOME/.local/bin:$PATH)
 script:
-  - find lib/lua -type f -name "*.lua" | xargs luac -p
+  - for file in $( find lib/lua -type f -name "*.lua" ); do echo Checking $file; luac -p $file; done
   - luac -p config/init.lua
   - cargo check
   - cargo test --verbose

--- a/ci.py
+++ b/ci.py
@@ -60,7 +60,7 @@ def check_release_branch(version):
 if __name__ == "__main__":
     args = docopt(DOCOPT_USAGE, version="ci.py v1.0")
     if args["travis-check"]:
-        travis_pr_branch = os.environ["TRAVIS_PR_BRANCH"]
+        travis_pr_branch = os.environ["TRAVIS_PULL_REQUEST_BRANCH"]
         if travis_pr_branch == "":
             print("Not running in a PR.")
             sys.exit(0)

--- a/ci.py
+++ b/ci.py
@@ -4,19 +4,6 @@ import sys
 import os
 import re
 
-"""way-cooler CI integration.
-
-Usage:
-  ci.py travis-check
-  ci.py bump <old version> <new version> [-v]
-  ci.py (-h | --help)
-  ci.py --version
-
-Options:
-  -h --help    Show this menu
-  -v           Be verbose, print actions taken
-  --version    Show version information
-"""
 from docopt import docopt
 
 VERSION_REGEX = '(\\d+\\.\\d+\\.\\d+)'
@@ -30,6 +17,20 @@ FILE_MAP = [
     ["Cargo.lock", CARGO_VERSION_LINE],
     ["README.md", README_CRATES_TAG]
 ]
+
+DOCOPT_USAGE = """way-cooler CI integration.
+
+Usage:
+  ci.py travis-check
+  ci.py bump <old version> <new version> [-v]
+  ci.py (-h | --help)
+  ci.py --version
+
+Options:
+  -h --help    Show this menu
+  -v           Be verbose, print actions taken
+  --version    Show version information
+"""
 
 failed = False
 
@@ -57,10 +58,8 @@ def check_release_branch(version):
         sys.exit(2)
 
 if __name__ == "__main__":
-    args = docopt(__doc__, version="ci.py v1.0")
-    verbose = args.v
-
-    if args.travis_check:
+    args = docopt(DOCOPT_USAGE, version="ci.py v1.0")
+    if args["travis-check"]:
         travis_pr_branch = os.environ["TRAVIS_PR_BRANCH"]
         if travis_pr_branch == "":
             print("Not running in a PR.")
@@ -72,9 +71,10 @@ if __name__ == "__main__":
         print("Checking versions in branch " + travis_pr_branch)
         check_release_branch(version_match)
 
-    elif args.bump:
+    elif args["bump"]:
         sys.stderr.write("Not supported yet")
         sys.exit(1)
+
     else:
         sys.stderr.write("Invalid arguments!\n")
         exit(1)

--- a/ci.py
+++ b/ci.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
             sys.exit(2)
         print("Checking if we can compile in release mode")
         retcode = subprocess.call(["cargo", "check", "--release"])
-        if retcode:
+        if retcode != 0:
             sys.stderr.write("cargo check --release failed with %d!\n" % retcode)
             sys.exit(2)
         print("All checks passed.")
@@ -87,6 +87,12 @@ if __name__ == "__main__":
 
     elif args["prepare-deploy"]:
         print("Not compiling for multiple targets yet :(")
+        print("cargo build --release --verbose")
+        retcode = subprocess.call(["cargo", "build", "--verbose", "--release"])
+        if retcode != 0:
+            sys.stderr.write("Cargo build exited with %s\n", retcode)
+            sys.exit(2)
+
         print("Moving `way-cooler` to `way-cooler_linux_x86_64`")
         build_dir = os.environ["TRAVIS_BUILD_DIR"]
         os.rename(build_dir + "/way-cooler", build_dir + "/way-cooler_linux_x86_64")

--- a/ci.py
+++ b/ci.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python2
+
+import sys
+
+from semver import semver
+
+"""way-cooler CI integration.
+
+Usage:
+  ci.py check <version> [-v]
+  ci.py bump <old version> <new version> [-v]
+  ci.py (-h | --help)
+  ci.py --version
+
+Options:
+  -h --help    Show this menu
+  -v           Be verbose, print actions taken
+  --version    Show version information
+"""
+from docopt import docopt
+
+VERSION_REGEX = '\d+\.\d+\.\d+'
+"""If we grab the first 'version=' line in the Cargo files we'll be fine."""
+CARGO_VERSION_LINE = '$version = "' + VERSION_REGEX + '"^'
+README_CRATES_TAG = ""
+
+def check_version(semver, verbose):
+    if verbose:
+        print("Verifying requirements for release version " + str(version))
+        print("Verifying Cargo.toml release...")
+
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__, version="ci.py v1.0")
+    verbose = args.v
+    if verbose:
+        print(args)
+
+    if args.check:
+        try:
+            version = semver.parse(args.version)
+            check_version(version, verbose)
+        except ValueError as e:
+            sys.stderr.write("Invalid version %s.\n" % args.version)
+            exit(1)
+
+    else if args.bump:
+        try:
+            old_version = semver.parse(args["old version"])
+            new_version = semver.parse(args["new version"])
+            bump_version(old_version, new_version, verbose)
+        except ValueError as e:
+            sys.stderr.write(
+                "Invalid version %s or %s.\n" % args["old_version"], args["new_version"])
+            exit(1)
+
+    else:
+        sys.stderr.write("Invalid arguments!\n")
+        exit(1)

--- a/ci.py
+++ b/ci.py
@@ -21,11 +21,11 @@ Options:
 """
 from docopt import docopt
 
-VERSION_REGEX = '\d+\.\d+\.\d+'
+VERSION_REGEX = '\\d+\\.\\d+\\.\\d+'
 BRANCH_REGEX = 'release-(' + VERSION_REGEX + ')'
 # If we grab the first 'version=' line in the Cargo files we'll be fine
 CARGO_VERSION_LINE = '$version = "' + VERSION_REGEX + '"^'
-README_CRATES_TAG = "crates\.io/-v\" + VERSION_REGEX + '-orange\.svg'
+README_CRATES_TAG = "crates\\.io/-v" + VERSION_REGEX + '-orange\\.svg'
 
 
 def check_release_branch(branch_version):

--- a/ci.py
+++ b/ci.py
@@ -34,8 +34,6 @@ Options:
   --version    Show version information
 """
 
-failed = False
-
 def check_file_version(file_name, regex, expected):
     reg = re.compile(regex)
     with open(file_name) as f:
@@ -59,12 +57,12 @@ def check_release_branch(version):
     return all_clear
 
 if __name__ == "__main__":
-    print("Running ci.py...")
+    print("Running way-cooler ci script...")
     args = docopt(DOCOPT_USAGE, version="ci.py v1.0")
     if args["travis-check"]:
         print("Running travis-check...")
         travis_pr_branch = os.environ["TRAVIS_PULL_REQUEST_BRANCH"]
-        if travis_pr_branch == "":
+        if not travis_pr_branch or travis_pr_branch == "":
             print("Not running in a PR.")
             sys.exit(0)
         print("PR " + travis_pr_branch + " detected, checking for versions.")
@@ -86,15 +84,17 @@ if __name__ == "__main__":
     elif args["prepare-deploy"]:
         print("Not compiling for multiple targets yet :(")
         print("cargo build --release --verbose")
-        retcode = subprocess.call(["cargo", "build", "--verbose", "--release"])
+        retcode = subprocess.call(["cargo", "build", "--release", "--verbose"])
         if retcode != 0:
-            sys.stderr.write("Cargo build exited with %s\n", retcode)
+            sys.stderr.write("Cargo build exited with {}\n".format(retcode))
             sys.exit(2)
 
         print("Moving way-cooler => way-cooler_linux_x86_64")
         build_dir = os.environ["TRAVIS_BUILD_DIR"]
-        os.rename(build_dir + "/target/release/way-cooler", build_dir + "/way-cooler_linux_x86_64")
+        os.rename(build_dir + "/target/release/way-cooler",
+                  build_dir + "/way-cooler_linux_x86_64")
 
     else:
         sys.stderr.write("Invalid arguments!\n")
+        print(DOCOPT_USAGE)
         sys.exit(1)

--- a/ci.py
+++ b/ci.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import re
+import subprocess
 
 from docopt import docopt
 
@@ -70,15 +71,25 @@ if __name__ == "__main__":
             sys.exit(0)
         print("Checking versions in branch " + travis_pr_branch)
         if not check_release_branch(version_match):
-            sys.stderr.write("Not all files matched!")
+            sys.stderr.write("Not all files matched!\n")
             sys.exit(2)
+        print("Checking if we can compile in release mode")
+        retcode = subprocess.call(["cargo", "check", "--release"])
+        if retcode:
+            sys.stderr.write("cargo check --release failed with %d!\n" % retcode)
+            sys.exit(2)
+        print("All checks passed.")
+
 
     elif args["bump"]:
         sys.stderr.write("Not supported yet")
         sys.exit(1)
 
     elif args["prepare-deploy"]:
-        sys.stderr.write("Not supported yet")
+        print("Not compiling for multiple targets yet :(")
+        print("Moving `way-cooler` to `way-cooler_linux_x86_64`")
+        build_dir = os.environ["TRAVIS_BUILD_DIR"]
+        os.rename(build_dir + "/way-cooler", build_dir + "/way-cooler_linux_x86_64")
 
     else:
         sys.stderr.write("Invalid arguments!\n")

--- a/ci.py
+++ b/ci.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     if args["travis-check"]:
         print("Running travis-check...")
         travis_pr_branch = os.environ["TRAVIS_PULL_REQUEST_BRANCH"]
-        if not travis_pr_branch or travis_pr_branch == "":
+        if not travis_pr_branch:
             print("Not running in a PR.")
             sys.exit(0)
         print("PR " + travis_pr_branch + " detected, checking for versions.")

--- a/ci.py
+++ b/ci.py
@@ -93,9 +93,9 @@ if __name__ == "__main__":
             sys.stderr.write("Cargo build exited with %s\n", retcode)
             sys.exit(2)
 
-        print("Moving `way-cooler` to `way-cooler_linux_x86_64`")
+        print("Moving way-cooler => way-cooler_linux_x86_64")
         build_dir = os.environ["TRAVIS_BUILD_DIR"]
-        os.rename(build_dir + "/way-cooler", build_dir + "/way-cooler_linux_x86_64")
+        os.rename(build_dir + "/target/release/way-cooler", build_dir + "/way-cooler_linux_x86_64")
 
     else:
         sys.stderr.write("Invalid arguments!\n")

--- a/ci.py
+++ b/ci.py
@@ -22,6 +22,7 @@ DOCOPT_USAGE = """way-cooler CI integration.
 
 Usage:
   ci.py travis-check
+  ci.py prepare-deploy
   ci.py bump <old version> <new version> [-v]
   ci.py (-h | --help)
   ci.py --version
@@ -75,6 +76,9 @@ if __name__ == "__main__":
     elif args["bump"]:
         sys.stderr.write("Not supported yet")
         sys.exit(1)
+
+    elif args["prepare-deploy"]:
+        sys.stderr.write("Not supported yet")
 
     else:
         sys.stderr.write("Invalid arguments!\n")

--- a/ci.py
+++ b/ci.py
@@ -59,13 +59,16 @@ def check_release_branch(version):
     return all_clear
 
 if __name__ == "__main__":
+    print("Running ci.py...")
     args = docopt(DOCOPT_USAGE, version="ci.py v1.0")
     if args["travis-check"]:
+        print("Running travis-check...")
         travis_pr_branch = os.environ["TRAVIS_PULL_REQUEST_BRANCH"]
         if travis_pr_branch == "":
             print("Not running in a PR.")
             sys.exit(0)
-        version_match = re.match(travis_pr_branch)
+        print("PR " + travis_pr_branch + " detected, checking for versions.")
+        version_match = re.match(BRANCH_REGEX, travis_pr_branch)
         if not version_match:
             print("Not in a release branch PR.")
             sys.exit(0)
@@ -73,12 +76,7 @@ if __name__ == "__main__":
         if not check_release_branch(version_match):
             sys.stderr.write("Not all files matched!\n")
             sys.exit(2)
-        print("Checking if we can compile in release mode")
-        retcode = subprocess.call(["cargo", "check", "--release"])
-        if retcode != 0:
-            sys.stderr.write("cargo check --release failed with %d!\n" % retcode)
-            sys.exit(2)
-        print("All checks passed.")
+        print("All version checks passed.")
 
 
     elif args["bump"]:


### PR DESCRIPTION
This PR adds deploy automation and more code checks in `.travis.yml`.

**Overall**
- Improvements in speed
- Clarity of the `travis.yml`
- Add `ci.py` with some actions which can be run locally

**Per-branch**
- Code will be checked for being able to compile without `--test` (prevent #115 issues where master branch didn't compile)

**Release branches**
- Travis should check if it is being run under a branch named `release-{version}`
- Travis should check that version numbers in the readme badges, `Cargo.toml`, and `Cargo.lock` match `{version}`
- ~~Also runs `cargo check --release` just in case~~

**Deploy**
- Travis is hooked into GitHub releases when a tag is pushed
- Should rebuild way-cooler and attach a `way-cooler_linux_x86_64` and `init.lua` to a GitHub release
- Should deploy to crates.io as well

Obviously, we won't know if the release works until we try it. This current script was made with many, many attempts and re-runs. The `release-0.3.3` branch may contain more fixes. If the upcoming 0.3.3 deploy does not work we will do so ourselves.