### PR TITLE
Better readme cratesio badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Way Cooler
 
 [![Gitter](https://badges.gitter.im/Immington-Industries/way-cooler.svg)](https://gitter.im/Immington-Industries/way-cooler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Crates.io](https://img.shields.io/badge/crates.io-v0.3.2-orange.svg)](https://crates.io/crate/way-cooler)
+[![Crates.io](https://img.shields.io/crates/v/way-cooler.svg)](https://crates.io/crate/way-cooler)
 [![Build Status](https://travis-ci.org/Immington-Industries/way-cooler.svg?branch=master)](https://travis-ci.org/Immington-Industries/way-cooler)
 [![Coverage Status](https://coveralls.io/repos/github/Immington-Industries/way-cooler/badge.svg)](https://coveralls.io/github/Immington-Industries/way-cooler)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Immington-Industries/way-cooler/)

--- a/ci.py
+++ b/ci.py
@@ -11,12 +11,10 @@ VERSION_REGEX = '(\\d+\\.\\d+\\.\\d+)'
 BRANCH_REGEX = '$release*' + VERSION_REGEX + '^'
 # If we grab the first 'version=' line in the Cargo files we'll be fine
 CARGO_VERSION_LINE = '$version = "' + VERSION_REGEX + '"^'
-README_CRATES_TAG = "/badge/crates\\.io/-v" + VERSION_REGEX
 
 FILE_REGEX_MAP = {
     "Cargo.toml": CARGO_VERSION_LINE,
     "Cargo.lock": CARGO_VERSION_LINE,
-    "README.md": README_CRATES_TAG
 }
 
 DOCOPT_USAGE = """way-cooler CI integration.
@@ -47,6 +45,8 @@ def check_file_version(file_name, regex, expected):
             else:
                 print('\t' + file_name + ": expected " + expected + ", got " + match)
                 return False
+        print('\t' + file_name + ": did not find any version match!")
+        return False
 
 def check_release_branch(version):
     all_clear = True


### PR DESCRIPTION
We don't need to version the crates.io badge in the readme, we can just ask for `way-cooler`.
Removed this check from `ci.py` and added an error for the edge case that no line in the file has any version matched.