### PR TITLE
4.1 layout fixes

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -56,6 +56,20 @@ pub extern fn output_resolution(output: WlcOutput,
 
 pub extern fn view_created(view: WlcView) -> bool {
     trace!("view_created: {:?}: \"{}\"", view, view.get_title());
+    if view.get_class().as_str() == "Background" {
+        info!("Setting background: {}", view.get_title());
+        view.send_to_back();
+        view.set_mask(1);
+        let output = view.get_output();
+        let resolution = output.get_resolution()
+            .expect("Couldn't get output resolution");
+        let fullscreen = Geometry {
+            origin: Point { x: 0, y: 0 },
+            size: resolution
+        };
+        view.set_geometry(ResizeEdge::empty(), fullscreen);
+        return true
+    }
     if let Ok(mut tree) = try_lock_tree() {
         tree.add_view(view).and_then(|_| {
             if view.get_class() == "Background" {

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -7,7 +7,7 @@ use petgraph::graph::NodeIndex;
 use rustwlc::WlcView;
 use uuid::Uuid;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FocusError {
     /// Reached a container where we can keep climbing the tree no longer.
     ///

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -134,8 +134,8 @@ impl LayoutTree {
     pub fn focus_on_next_container(&mut self, mut parent_ix: NodeIndex) {
         while self.tree.node_type(parent_ix)
             .expect("Node not part of the tree") != ContainerType::Workspace {
-            if let Ok(view_ix) = self.tree.descendant_of_type_right(parent_ix,
-                                                            ContainerType::View) {
+                if let Ok(view_ix) = self.tree.descendant_of_type(parent_ix,
+                                                                  ContainerType::View) {
                 match self.tree[view_ix]
                                     .get_handle().expect("view had no handle") {
                     Handle::View(view) => view.focus(),

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -132,6 +132,22 @@ impl LayoutTree {
     /// tree until either a view is found or the workspace is (in which case
     /// it set the active container to the root container of the workspace)
     pub fn focus_on_next_container(&mut self, mut parent_ix: NodeIndex) {
+        let last_ix;
+        {
+            let path = self.tree.active_path();
+            last_ix = path[path.len() - 1].0;
+        }
+        match self.tree[last_ix] {
+            Container::View { handle, .. } => {
+                handle.focus();
+                self.active_container = Some(last_ix);
+                return
+            },
+            Container::Container { .. } => {
+                parent_ix = last_ix;
+            },
+            _ => {}
+        }
         while self.tree.node_type(parent_ix)
             .expect("Node not part of the tree") != ContainerType::Workspace {
                 if let Ok(view_ix) = self.tree.descendant_of_type(parent_ix,

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -234,6 +234,9 @@ impl LayoutTree {
     /// it will remain pointing at the previous parent container.
     pub fn float_container(&mut self, id: Uuid) -> CommandResult {
         let node_ix = try!(self.tree.lookup_id(id).ok_or(TreeError::NodeNotFound(id)));
+        if self.root_container_ix() == Some(node_ix) {
+            return Err(TreeError::InvalidOperationOnRootContainer(id))
+        }
         if self.tree[node_ix].floating() {
             warn!("Trying to float an already floating container");
             return Err(TreeError::Layout(LayoutErr::AlreadyFloating(id)));

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -234,7 +234,7 @@ impl LayoutTree {
     /// it will remain pointing at the previous parent container.
     pub fn float_container(&mut self, id: Uuid) -> CommandResult {
         let node_ix = try!(self.tree.lookup_id(id).ok_or(TreeError::NodeNotFound(id)));
-        if self.root_container_ix() == Some(node_ix) {
+        if self.tree.is_root_container(node_ix) {
             return Err(TreeError::InvalidOperationOnRootContainer(id))
         }
         if self.tree[node_ix].floating() {

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -1,11 +1,11 @@
 use std::cmp;
 
 use petgraph::graph::NodeIndex;
-use rustwlc::{Geometry, Point, Size, ResizeEdge, ViewType};
+use rustwlc::{Geometry, Point, Size, ResizeEdge};
 
 use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
-use super::super::core::container::{Container, ContainerType, Layout, Handle};
+use super::super::core::container::{Container, ContainerType, Layout};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -8,7 +8,7 @@ use super::super::commands::CommandResult;
 use super::super::core::container::{Container, ContainerType, Layout};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum LayoutErr {
     /// The node behind the UUID was asked to ground when it was already grounded.
     AlreadyGrounded(Uuid),

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -243,10 +243,6 @@ impl LayoutTree {
         }
         let output_ix = try!(self.tree.ancestor_of_type(node_ix, ContainerType::Output)
                              .map_err(|err| TreeError::PetGraph(err)));
-        let handle = match self.tree[node_ix].get_handle() {
-            Some(Handle::View(view)) => view,
-            _ => unreachable!()
-        };
         let output_size = match self.tree[output_ix] {
             Container::Output { handle, .. } => {
                 handle.get_resolution().expect("Output had no resolution")
@@ -258,28 +254,25 @@ impl LayoutTree {
             try!(container.set_floating(true)
                 .map_err(|_| TreeError::UuidWrongType(id, vec!(ContainerType::View,
                                                                 ContainerType::Container))));
-            // We float pop-ups as soon as they spawn, this is so we don't resize them
-            if handle.get_type() == ViewType::empty() {
-                let new_geometry = Geometry {
-                        size: Size {
-                            h: output_size.h / 2,
-                            w: output_size.w / 2
-                        },
-                        origin: Point {
-                            x: (output_size.w / 2 - output_size.w / 4) as i32 ,
-                            y: (output_size.h / 2 - output_size.h / 4) as i32
-                        }
-                    };
-                match *container {
-                    Container::View { handle, .. } => {
-                        handle.set_geometry(ResizeEdge::empty(), new_geometry);
+            let new_geometry = Geometry {
+                    size: Size {
+                        h: output_size.h / 2,
+                        w: output_size.w / 2
                     },
-                    Container::Container { ref mut geometry, .. } => {
-                        *geometry = new_geometry
-                    },
-                    _ => return Err(TreeError::UuidWrongType(id, vec!(ContainerType::View,
-                                                                    ContainerType::Container)))
-                }
+                    origin: Point {
+                        x: (output_size.w / 2 - output_size.w / 4) as i32 ,
+                        y: (output_size.h / 2 - output_size.h / 4) as i32
+                    }
+                };
+            match *container {
+                Container::View { handle, .. } => {
+                    handle.set_geometry(ResizeEdge::empty(), new_geometry);
+                },
+                Container::Container { ref mut geometry, .. } => {
+                    *geometry = new_geometry
+                },
+                _ => return Err(TreeError::UuidWrongType(id, vec!(ContainerType::View,
+                                                                ContainerType::Container)))
             }
         }
         let root_ix = self.tree.root_ix();

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -1,11 +1,11 @@
 use std::cmp;
 
 use petgraph::graph::NodeIndex;
-use rustwlc::{Geometry, Point, Size, ResizeEdge};
+use rustwlc::{Geometry, Point, Size, ResizeEdge, ViewType};
 
 use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
-use super::super::core::container::{Container, ContainerType, Layout};
+use super::super::core::container::{Container, ContainerType, Layout, Handle};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -243,6 +243,10 @@ impl LayoutTree {
         }
         let output_ix = try!(self.tree.ancestor_of_type(node_ix, ContainerType::Output)
                              .map_err(|err| TreeError::PetGraph(err)));
+        let handle = match self.tree[node_ix].get_handle() {
+            Some(Handle::View(view)) => view,
+            _ => unreachable!()
+        };
         let output_size = match self.tree[output_ix] {
             Container::Output { handle, .. } => {
                 handle.get_resolution().expect("Output had no resolution")
@@ -254,25 +258,28 @@ impl LayoutTree {
             try!(container.set_floating(true)
                 .map_err(|_| TreeError::UuidWrongType(id, vec!(ContainerType::View,
                                                                 ContainerType::Container))));
-            let new_geometry = Geometry {
-                    size: Size {
-                        h: output_size.h / 2,
-                        w: output_size.w / 2
+            // We float pop-ups as soon as they spawn, this is so we don't resize them
+            if handle.get_type() == ViewType::empty() {
+                let new_geometry = Geometry {
+                        size: Size {
+                            h: output_size.h / 2,
+                            w: output_size.w / 2
+                        },
+                        origin: Point {
+                            x: (output_size.w / 2 - output_size.w / 4) as i32 ,
+                            y: (output_size.h / 2 - output_size.h / 4) as i32
+                        }
+                    };
+                match *container {
+                    Container::View { handle, .. } => {
+                        handle.set_geometry(ResizeEdge::empty(), new_geometry);
                     },
-                    origin: Point {
-                        x: (output_size.w / 2 - output_size.w / 4) as i32 ,
-                        y: (output_size.h / 2 - output_size.h / 4) as i32
-                    }
-                };
-            match *container {
-                Container::View { handle, .. } => {
-                    handle.set_geometry(ResizeEdge::empty(), new_geometry);
-                },
-                Container::Container { ref mut geometry, .. } => {
-                    *geometry = new_geometry
-                },
-                _ => return Err(TreeError::UuidWrongType(id, vec!(ContainerType::View,
-                                                                  ContainerType::Container)))
+                    Container::Container { ref mut geometry, .. } => {
+                        *geometry = new_geometry
+                    },
+                    _ => return Err(TreeError::UuidWrongType(id, vec!(ContainerType::View,
+                                                                    ContainerType::Container)))
+                }
             }
         }
         let root_ix = self.tree.root_ix();

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -278,13 +278,9 @@ impl LayoutTree {
         let root_ix = self.tree.root_ix();
         let root_c_ix = try!(self.tree.follow_path_until(root_ix, ContainerType::Container)
                              .map_err(|_| TreeError::NoActiveContainer));
-        let next_ix = self.tree.next_sibling(node_ix)
-            .unwrap_or_else(|| self.tree.parent_of(node_ix).expect("node_ix had no parent!"));
         try!(self.tree.move_into(node_ix, root_c_ix)
              .map_err(|err| TreeError::PetGraph(err)));
-        if !self.tree[next_ix].floating() {
-            self.tree.set_ancestor_paths_active(next_ix);
-        }
+        self.tree.set_ancestor_paths_active(node_ix);
         let parent_ix = self.tree.parent_of(root_c_ix).unwrap();
         self.layout(parent_ix);
         Ok(())

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -7,7 +7,7 @@ use super::super::commands::CommandResult;
 use super::super::core::{Direction, ShiftDirection, TreeError};
 use super::super::core::container::{Container, ContainerType, Handle, Layout};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum MovementError {
     /// Attempted to move the node behind the UUID in the given direction,
     /// which would cause it to leave its siblings.

--- a/src/layout/actions/resize.rs
+++ b/src/layout/actions/resize.rs
@@ -8,7 +8,7 @@ use super::super::commands::{CommandResult};
 use super::super::core::container::{ContainerType, MIN_SIZE};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ResizeErr {
     /// Expected the node associated with the UUID to be floating.
     ExpectedFloating(Uuid),

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -195,6 +195,7 @@ impl LayoutTree {
 
             // Update the active container
             if let Ok(parent_ix) = maybe_active_parent {
+                self.tree.set_ancestor_paths_active(parent_ix);
                 let ctype = self.tree.node_type(parent_ix).unwrap_or(ContainerType::Root);
                 if ctype == ContainerType::Container {
                     self.focus_on_next_container(parent_ix);

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -267,6 +267,7 @@ impl Tree {
 
     /// Adds a view to the workspace of the active container
     pub fn add_view(&mut self, view: WlcView) -> CommandResult {
+        // TODO Move this out of commands
         let tree = &mut self.0;
         let output = view.get_output();
         if tree.get_active_container().is_none() {
@@ -276,14 +277,14 @@ impl Tree {
         let v_type = view.get_type();
         let v_class = view.get_class();
         // If it is empty, don't add to tree
-        if v_type != ViewType::empty() {
+        /*if v_type != ViewType::empty() {
             // Now focused on something outside the tree,
             // have to unset the active container
             if !tree.active_is_root() {
                 tree.unset_active_container();
             }
             return Ok(())
-        }
+        }*/
         if v_class.as_str() == "Background" {
             info!("Setting background: {}", view.get_title());
             view.send_to_back();
@@ -297,8 +298,12 @@ impl Tree {
             view.set_geometry(ResizeEdge::empty(), fullscreen);
             return Ok(());
         }
-        try!(tree.add_view(view));
-        tree.normalize_view(view);
+        let c_id = try!(tree.add_view(view)).get_id();
+        if v_type != ViewType::empty() {
+            try!(tree.float_container(c_id));
+        } else {
+            tree.normalize_view(view);
+        }
         tree.layout_active_of(ContainerType::Workspace);
         Ok(())
     }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -267,17 +267,16 @@ impl Tree {
 
     /// Adds a view to the workspace of the active container
     pub fn add_view(&mut self, view: WlcView) -> CommandResult {
-        // TODO Move this out of commands
         let tree = &mut self.0;
         let output = view.get_output();
         if tree.get_active_container().is_none() {
             return Err(TreeError::NoActiveContainer)
         }
         view.set_mask(output.get_mask());
-        let c_id = try!(tree.add_view(view)).get_id();
         if view.get_type() != ViewType::empty() {
-            try!(tree.float_container(c_id));
+            try!(tree.add_floating_view(view));
         } else {
+            try!(tree.add_view(view));
             tree.normalize_view(view);
         }
         tree.layout_active_of(ContainerType::Workspace);

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -285,9 +285,7 @@ impl Tree {
 
     /// Attempts to remove a view from the tree. If it is not in the tree it fails.
     ///
-    /// This will NOT close the handle behind the view, and should only be called
-    /// on views that have already been slated for removal from the wlc pool.
-    /// Otherwise you leak a `WlcView`
+    /// This will close the handle behind the view.
     pub fn remove_view(&mut self, view: WlcView) -> CommandResult {
         let result;
         match self.0.remove_view(&view) {

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -5,7 +5,7 @@ use super::{Action, ActionErr, Container, ContainerType, Direction, Handle, Layo
 use super::Tree;
 
 use uuid::Uuid;
-use rustwlc::{Geometry, Point, ResizeEdge, WlcView, WlcOutput, ViewType};
+use rustwlc::{Point, ResizeEdge, WlcView, WlcOutput, ViewType};
 use rustc_serialize::json::{Json, ToJson};
 
 pub type CommandResult = Result<(), TreeError>;
@@ -274,32 +274,8 @@ impl Tree {
             return Err(TreeError::NoActiveContainer)
         }
         view.set_mask(output.get_mask());
-        let v_type = view.get_type();
-        let v_class = view.get_class();
-        // If it is empty, don't add to tree
-        /*if v_type != ViewType::empty() {
-            // Now focused on something outside the tree,
-            // have to unset the active container
-            if !tree.active_is_root() {
-                tree.unset_active_container();
-            }
-            return Ok(())
-        }*/
-        if v_class.as_str() == "Background" {
-            info!("Setting background: {}", view.get_title());
-            view.send_to_back();
-            let output = view.get_output();
-            let resolution = output.get_resolution()
-                .expect("Couldn't get output resolution");
-            let fullscreen = Geometry {
-                origin: Point { x: 0, y: 0 },
-                size: resolution
-            };
-            view.set_geometry(ResizeEdge::empty(), fullscreen);
-            return Ok(());
-        }
         let c_id = try!(tree.add_view(view)).get_id();
-        if v_type != ViewType::empty() {
+        if view.get_type() != ViewType::empty() {
             try!(tree.float_container(c_id));
         } else {
             tree.normalize_view(view);

--- a/src/layout/core/action.rs
+++ b/src/layout/core/action.rs
@@ -7,7 +7,7 @@ pub struct Action {
     pub edges: ResizeEdge
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ActionErr {
     /// Tried to start an action, but an action was already in progress
     #[allow(dead_code)]

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -17,7 +17,7 @@ use super::path::{Path, PathBuilder};
 
 use layout::{Container, ContainerType, Handle};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GraphError {
     /// These nodes were not siblings.
     NotSiblings(NodeIndex, NodeIndex),

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -626,6 +626,7 @@ impl InnerTree {
 
     /// Attempts to get a descendant of the matching type.
     /// Looks down the right side of the tree first
+    #[allow(dead_code)]
     pub fn descendant_of_type_right(&self, node_ix: NodeIndex,
                                     container_type: ContainerType) -> Result<NodeIndex, GraphError> {
         if let Some(container) = self.get(node_ix) {

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -592,14 +592,15 @@ impl InnerTree {
     /// Note this does *NOT* check the given node.
     pub fn ancestor_of_type(&self, node_ix: NodeIndex,
                            container_type: ContainerType) -> Result<NodeIndex, GraphError> {
-        let mut curr_ix = node_ix;
-        while let Ok(parent_ix) = self.parent_of(curr_ix) {
+        let mut cur_ix = node_ix;
+        while let Ok(parent_ix) = self.parent_of(cur_ix) {
             let parent = self.graph.node_weight(parent_ix)
                 .expect("ancestor_of_type: parent_of invalid");
             if parent.get_type() == container_type {
                 return Ok(parent_ix)
             }
-            curr_ix = parent_ix;
+            assert!(cur_ix != parent_ix, "Parent of node was itself!");
+            cur_ix = parent_ix;
         }
         return Err(GraphError::NotFound(container_type, node_ix));
     }

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -711,12 +711,6 @@ impl InnerTree {
     /// If a divergent path is detected, that edge is deactivated in favor of
     /// the one that leads to this node.
     pub fn set_ancestor_paths_active(&mut self, mut node_ix: NodeIndex) {
-        if cfg!(debug_assertions) {
-            if self[node_ix].floating() {
-                error!("{:?} was set active, but it is floating!\n{:#?}", node_ix, self);
-                panic!("A node that was floating was set to be active!")
-            }
-        }
         // Make sure that any children of this node are inactive
         for child_ix in self.children_of(node_ix) {
             let edge_ix = self.graph.find_edge(node_ix, child_ix)
@@ -742,11 +736,8 @@ impl InnerTree {
         }
     }
 
-    /// Gets the next sibling to focus on, assuming child_ix would be removed from parent_ix.
-    /// If there are no other siblings to focus on, parent_ix is returned.
-    ///
-    /// # Panics
-    /// This will panic if `child_ix` is not a child of `parent_ix`
+    /// Gets the next sibling (if any) to focus on, assuming node_ix would be removed
+    /// from its parent.
     pub fn next_sibling(&self, node_ix: NodeIndex) -> Option<NodeIndex> {
         let parent_ix = self.parent_of(node_ix)
             .expect("Could not get parent of node!");

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -241,7 +241,7 @@ impl LayoutTree {
     }
 
     /// Add a new view container with the given WlcView to the active container
-    pub fn add_view(&mut self, view: WlcView) -> CommandResult {
+    pub fn add_view(&mut self, view: WlcView) -> Result<&Container, TreeError> {
         if let Some(mut active_ix) = self.active_container {
             let parent_ix = self.tree.parent_of(active_ix)
                 .expect("Active container had no parent");
@@ -258,7 +258,8 @@ impl LayoutTree {
                                               true);
             self.tree.set_child_pos(view_ix, prev_pos);
             self.validate();
-            return self.set_active_node(view_ix)
+            try!(self.set_active_node(view_ix));
+            return Ok(&self.tree[view_ix])
         }
         self.validate();
         Err(TreeError::NoActiveContainer)

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -18,7 +18,7 @@ use super::super::core::graph_tree::GraphError;
 
 use super::super::commands::CommandResult;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Direction {
     Up,
     Down,
@@ -70,7 +70,7 @@ impl Direction {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TreeError {
     /// A Node can not be found in the tree with this Node Handle.
     NodeNotFound(Uuid),
@@ -1248,6 +1248,6 @@ pub mod tests {
         tree.switch_to_workspace("3");
         assert_eq!(tree.get_active_container().unwrap().get_type(), ContainerType::Container);
         let uuid = tree.get_active_container().unwrap().get_id();
-        assert!(tree.float_container(uuid).is_ok());
+        assert_eq!(tree.float_container(uuid), Err(TreeError::InvalidOperationOnRootContainer(uuid)));
     }
 }

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -1241,4 +1241,13 @@ pub mod tests {
         tree.switch_to_workspace("2");
         tree.validate_path();
     }
+
+    #[test]
+    fn empty_workspace_float_test() {
+        let mut tree = basic_tree();
+        tree.switch_to_workspace("3");
+        assert_eq!(tree.get_active_container().unwrap().get_type(), ContainerType::Container);
+        let uuid = tree.get_active_container().unwrap().get_id();
+        assert!(tree.float_container(uuid).is_ok());
+    }
 }

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -232,6 +232,7 @@ impl LayoutTree {
     }
 
     /// Determines if the active container is the root container
+    #[allow(dead_code)]
     pub fn active_is_root(&self) -> bool {
         if let Some(active_ix) = self.active_container {
             self.tree.is_root_container(active_ix)
@@ -273,7 +274,8 @@ impl LayoutTree {
             let view_ix = self.tree.add_child(root_ix,
                                              Container::new_view(view),
                                              false);
-            self.tree[view_ix].set_floating(true);
+            self.tree[view_ix].set_floating(true)
+                .expect("Could not float view we just made");
             return Ok(&self.tree[view_ix])
         }
         self.validate();

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -571,14 +571,6 @@ impl LayoutTree {
             }
         }
         validate_edge_count(self, self.tree.root_ix());
-        let root_ix = self.tree.root_ix();
-        for node_ix in self.tree.follow_path_until(root_ix, ContainerType::View) {
-            if self.tree[node_ix].floating() {
-                error!("{:?} cannot be both on the active path and floating!\n{:#?}",
-                       node_ix, self);
-                panic!("Found node that was on the active path and floating!");
-            }
-        }
     }
 
     /// Validates the tree


### PR DESCRIPTION
* Fixes bug where floating an empty workspace hangs Way Cooler (#161)
* Fixes popups not being part of the tree (including dmenu) (#156, #152)
* Active path is now searched to determine next container to focus on (#130)
  + Doesn't completely fix issue, a list of the path history will be needed to fix focus history within a container.
* Errors in the tree can now be compared against each other.
* Handling of the background special case is no longer part of the trees job (moved to `callbacks.rs`)