### PR TITLE
Static init file, Fixes #124

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -83,8 +83,8 @@ local keys = {
   key({ mod }, "h", "split_horizontal"),
   key({ mod }, "v", "split_vertical"),
   key({ mod }, "e", "horizontal_vertical_switch"),
-  key({ mod }, "q", "close_window"),
-  key({ mod, "Shift"}, "space", "toggle_float_active"),
+  key({ mod, "Shift" }, "q", "close_window"),
+  key({ mod, "Shift" }, "space", "toggle_float_active"),
   key({ mod }, "space", "toggle_float_focus")
 
   -- Quitting way-cooler is hardcoded to Alt+Shift+Esc.

--- a/src/lua/init_path.rs
+++ b/src/lua/init_path.rs
@@ -10,6 +10,8 @@ use std::io::Result as IOResult;
 pub const INIT_FILE: &'static str = "init.lua";
 pub const INIT_FILE_FALLBACK_PATH: &'static str = "/etc/way-cooler/";
 
+pub const DEFAULT_CONFIG: &'static str = include_str!("../../config/init.lua");
+
 #[inline]
 fn read_file<P: AsRef<Path>>(path: P) -> IOResult<File> {
     OpenOptions::new().read(true).open(path)
@@ -71,17 +73,13 @@ fn get_config_file() -> Result<File, &'static str> {
     }
 
     warn!("way-cooler was unable to find an init file. \
-           This is currently required to use way-cooler.");
+           Using our default, pre-compiled init.lua.");
     warn!("Our default init.lua is available on GitHub, \
            it is included with the source.");
     warn!("You may place it in ~/.config/way-cooler/init.lua, \
            or a similar folder if you use $XDG_CONFIG_HOME, or /etc/way-cooler.");
     warn!("You may also use the environment variable $WAY_COOLER_INIT_FILE to point \
            directly to the file of your choice.");
-
-    info!("The init file will be included with way-cooler in the next release. If you \
-           do not have one or do not wish to customize we will always have the default \
-           to fall back on.");
 
     return Err("Could not find an init file in any path!")
 }

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -111,8 +111,10 @@ pub fn init() {
                     .expect("Unable to load init file");
                 debug!("Read init.lua successfully");
             }
-            Err(reason) => {
-                panic!("Unable to load init file: {}", reason)
+            Err(_) => {
+                debug!("Defaulting to pre-compiled init.lua");
+                let _: () = lua.execute(init_path::DEFAULT_CONFIG)
+                    .expect("Unable to load pre-compiled init file");
             }
         }
     }


### PR DESCRIPTION
* Way Cooler will now default to a standard init file if one could not be found on the system.
* Updated default `close_window` keybinding to `<mod>+shift+q`, which is a little safer and less likely to be accidentally pressed on some keyboards.