### PR TITLE
In-place restart

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -105,6 +105,10 @@ for _, key in pairs(keys) do
     config.register_key(key)
 end
 
+function cleanup_background()
+  os.execute("pkill way-cooler-bg")
+end
+
 
 -- Execute some code after Way Cooler is finished initializing
 function way_cooler_init()
@@ -118,8 +122,13 @@ end
 
 --- Execute some code when Way Cooler restarts
 function way_cooler_restart()
-    os.execute("pkill way-cooler-bg")
+  cleanup_background()
 end
+
+function way_cooler_terminate()
+  cleanup_background()
+end
+
 
 -- To use plugins such as bars, or to start other programs on startup,
 -- call util.exec.spawn_once, which will not spawn copies after a config reload.

--- a/config/init.lua
+++ b/config/init.lua
@@ -116,6 +116,11 @@ function way_cooler_init()
   end
 end
 
+--- Execute some code when Way Cooler restarts
+function way_cooler_restart()
+    os.execute("pkill way-cooler-bg")
+end
+
 -- To use plugins such as bars, or to start other programs on startup,
 -- call util.exec.spawn_once, which will not spawn copies after a config reload.
 

--- a/config/init.lua
+++ b/config/init.lua
@@ -85,7 +85,8 @@ local keys = {
   key({ mod }, "e", "horizontal_vertical_switch"),
   key({ mod }, "q", "close_window"),
   key({ mod, "Shift"}, "space", "toggle_float_active"),
-  key({ mod }, "space", "toggle_float_focus")
+  key({ mod }, "space", "toggle_float_focus"),
+  key({ mod, "Shift" }, "r", "way_cooler_restart")
 
   -- Quitting way-cooler is hardcoded to Alt+Shift+Esc.
   -- This my be modifiable in the future

--- a/config/init.lua
+++ b/config/init.lua
@@ -85,7 +85,7 @@ local keys = {
   key({ mod }, "e", "horizontal_vertical_switch"),
   key({ mod, "Shift" }, "q", "close_window"),
   key({ mod, "Shift" }, "space", "toggle_float_active"),
-  key({ mod }, "space", "toggle_float_focus")
+  key({ mod }, "space", "toggle_float_focus"),
   key({ mod, "Shift" }, "r", "way_cooler_restart")
 
   -- Quitting way-cooler is hardcoded to Alt+Shift+Esc.

--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -2,21 +2,25 @@
 local rust = __rust
 __rust = nil
 
+local way_cooler_table = {}
+local way_cooler_mt = {}
+local config_table = {}
+local config_mt = {}
+__key_map = {}
+
 -- Initialize the workspaces
-config.init_workspaces = function(settings)
+config_table.init_workspaces = function(settings)
     assert(type(settings) == 'table', "settings: expected table")
     for ix, val in pairs(settings) do
         assert(type(ix) == 'number', "settings: expected number-indexed array")
         assert(type(val) == 'table', "settings: expected array of tables")
-
         val.name = val.name or ""
         val.mode = val.mode or "tiling"
     end
     rust.init_workspaces(settings)
 end
-
 -- Create a new keybinding to register with Rust
-config.key = function(mods, key, action, loop)
+config_table.key = function(mods, key, action, loop)
     assert(type(mods) == 'table', "modifiers: expected table")
     assert(type(key) == 'string', "key: expected string")
     if loop == nil then loop = true end
@@ -27,23 +31,19 @@ config.key = function(mods, key, action, loop)
         mods = mods, key = key, action = action, loop = loop
     }
 end
-
 local use_key = ", use the `key` or `config.key` method to create a keybinding"
-
 -- Converts a list of modifiers to a string
 local function keymods_to_string(mods, key)
     table.insert(mods, key)
     return table.concat(mods, ',')
 end
-
 -- Save the action at the __key_map and tell Rust to register the Lua key
 local function register_lua_key(index, action, loop)
     local map_ix = rust.register_lua_key(index, loop)
     __key_map[map_ix] = action
 end
-
 -- Register a keybinding
-config.register_key = function(key)
+config_table.register_key = function(key)
     assert(key.mods, "keybinding missing modifiers" .. use_key)
     assert(key.key, "keybinding missing modifiers" .. use_key)
     assert(key.action, "keybinding missing action" .. use_key)
@@ -65,3 +65,59 @@ config.register_key = function(key)
         error("keybinding action: expected string or a function"..use_key, 2)
     end
 end
+-- Register callback to execute on restart
+way_cooler_table.on_restart = function(callback)
+    assert(callback, "missing callback")
+    assert(type(callback) == 'function', "callback: expected function")
+    __rust.restart_callback = callback
+end
+-- Register a function to execute on terminate
+way_cooler_table.on_terminate = function(callback)
+    assert(callback, "missing callback")
+    assert(type(callback) == 'function', "callback: expected function")
+    __rust.on_terminate = callback
+end
+-- This could technically be called by clients if they want, it should be more hidden.
+way_cooler_table.handle_termination = function()
+    if __rust.on_terminate ~= nil then
+        __rust.on_terminate()
+    end
+end
+way_cooler_table.handle_restart = function()
+    if __rust.on_restart ~= nil then
+        __rust.on_terminate()
+    end
+end
+
+way_cooler_mt.__index = function(_table, key)
+    if way_cooler[key] == nil then
+        if type(key) ~= 'string' then
+            error("Invalid key, string expected", 1)
+        else
+            return __rust.ipc_get(key)
+        end
+    else
+        return way_cooler[key]
+    end
+end
+way_cooler_mt.__new_index = function(_table, key, value)
+    if type(key) ~= 'string' then
+        error("Invlaid key, string expected", 1)
+    else
+        __rust.ipc_set(key, value)
+    end
+end
+way_cooler_mt.__to_string = function(_table)
+    return "Way Cooler IPC access"
+end
+config_mt.__to_string = function(_table)
+    return "Way Cooler config access"
+end
+way_cooler_mt.__metatable = "Cannot modify"
+config_mt.__metatable = "Cannot modify"
+
+config = config_table
+setmetatable(config, config_mt)
+way_cooler = way_cooler_table
+setmetatable(way_cooler, way_cooler_table)
+setmetatable(__key_map, { __metatable = "cannot modify" })

--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -69,23 +69,23 @@ end
 way_cooler_table.on_restart = function(callback)
     assert(callback, "missing callback")
     assert(type(callback) == 'function', "callback: expected function")
-    __rust.restart_callback = callback
+    rust.restart_callback = callback
 end
 -- Register a function to execute on terminate
 way_cooler_table.on_terminate = function(callback)
     assert(callback, "missing callback")
     assert(type(callback) == 'function', "callback: expected function")
-    __rust.on_terminate = callback
+    rust.on_terminate = callback
 end
 -- This could technically be called by clients if they want, it should be more hidden.
 way_cooler_table.handle_termination = function()
-    if __rust.on_terminate ~= nil then
-        __rust.on_terminate()
+    if rust.on_terminate ~= nil then
+        rust.on_terminate()
     end
 end
 way_cooler_table.handle_restart = function()
-    if __rust.on_restart ~= nil then
-        __rust.on_terminate()
+    if rust.on_restart ~= nil then
+        rust.on_terminate()
     end
 end
 
@@ -94,7 +94,7 @@ way_cooler_mt.__index = function(_table, key)
         if type(key) ~= 'string' then
             error("Invalid key, string expected", 1)
         else
-            return __rust.ipc_get(key)
+            return rust.ipc_get(key)
         end
     else
         return way_cooler[key]
@@ -104,7 +104,7 @@ way_cooler_mt.__new_index = function(_table, key, value)
     if type(key) ~= 'string' then
         error("Invlaid key, string expected", 1)
     else
-        __rust.ipc_set(key, value)
+        rust.ipc_set(key, value)
     end
 end
 way_cooler_mt.__to_string = function(_table)

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -109,7 +109,7 @@ fn launch_terminal() {
         .map(RegistryGetData::resolve).and_then(|(_, data)| {
         data.as_string().map(str::to_string)
             .ok_or(RegistryError::KeyNotFound)
-    }).unwrap_or("weston_terminal".to_string());
+    }).unwrap_or("weston-terminal".to_string());
 
     Command::new("sh").arg("-c")
         .arg(command)

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -10,6 +10,7 @@ use registry::{self, RegistryError, RegistryGetData};
 use commands::{self, CommandFn};
 use layout::try_lock_tree;
 use lua::{self, LuaQuery};
+use super::super::keys;
 
 /// Register the default commands in the API.
 ///
@@ -28,6 +29,7 @@ pub fn register_defaults() {
     register("print_pointer", Arc::new(print_pointer));
 
     register("dmenu_eval", Arc::new(dmenu_eval));
+    register("way_cooler_restart", Arc::new(way_cooler_restart));
     register("dmenu_lua_dofile", Arc::new(dmenu_lua_dofile));
 
     /// Generate switch_workspace methods and register them
@@ -181,4 +183,11 @@ fn dmenu_eval() {
                .expect("Unable to contact Lua").recv().expect("Can't get reply");
            trace!("Lua result: {:?}", result)
     }).expect("Unable to spawn thread");
+}
+
+fn way_cooler_restart() {
+    keys::clear_keys();
+    if let Err(err) = lua::send(lua::LuaQuery::Restart) {
+        warn!("Could not send restart signal, {:?}", err);
+    }
 }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -51,6 +51,16 @@ pub fn init() {
                                .expect("Error reading commands::quit")));
 }
 
+/// Clears all the keys from Way Cooler's memory.
+pub fn clear_keys() {
+    {
+        let mut bindings = BINDINGS.write()
+            .expect("Keybindings/clear_keys: unable to lock keybindings");
+        bindings.drain();
+    }
+    init();
+}
+
 /// Get a key mapping from the list.
 pub fn get(key: &KeyPress) -> Option<KeyEvent> {
     let bindings = BINDINGS.read()

--- a/src/lua/rust_interop.rs
+++ b/src/lua/rust_interop.rs
@@ -5,7 +5,6 @@ use std::ops::Deref;
 
 use hlua::{self, Lua, LuaTable};
 use hlua::any::AnyLuaValue;
-use hlua::any::AnyLuaValue::*;
 
 use registry::{self, RegistryError, AccessFlags};
 use commands;
@@ -27,24 +26,9 @@ pub fn register_libraries(lua: &mut Lua) {
         rust_table.set("register_lua_key", hlua::function2(register_lua_key));
         rust_table.set("register_command_key", hlua::function3(register_command_key));
         rust_table.set("keypress_index", hlua::function1(keypress_index));
-    }
-    {
-        let mut ipc_table: LuaTable<_> = lua.empty_array("way_cooler");
-        ipc_table.set("run", hlua::function1(ipc_run));
-        ipc_table.set("get", hlua::function1(ipc_get));
-        ipc_table.set("set", hlua::function2(ipc_set));
-        let mut meta_ipc = ipc_table.get_or_create_metatable();
-        meta_ipc.set("__metatable", "Turtles all the way down");
-        meta_ipc.set("__index", hlua::function2(index));
-        meta_ipc.set("__newindex", hlua::function3(new_index));
-    }
-    {
-        let config_table: LuaTable<_> = lua.empty_array("config");
-        let mut meta_config = config_table.get_or_create_metatable();
-        meta_config.set("__metatable", "Turtles all the way down");
-    }
-    {
-        let _keypress_table: LuaTable<_> = lua.empty_array("__key_map");
+        rust_table.set("ipc_run", hlua::function1(ipc_run));
+        rust_table.set("ipc_get", hlua::function1(ipc_get));
+        rust_table.set("ipc_set", hlua::function2(ipc_set));
     }
     trace!("Executing Lua init...");
     let init_code = include_str!("../../lib/lua/lua_init.lua");
@@ -52,7 +36,6 @@ pub fn register_libraries(lua: &mut Lua) {
         .expect("Unable to execute Lua init code!");
     trace!("Lua register_libraries complete");
 }
-
 
 /// Run a command
 fn ipc_run(command: String) -> Result<(), &'static str> {
@@ -103,24 +86,6 @@ fn ipc_set(key: String, value: AnyLuaValue) -> Result<(), &'static str> {
                 }
             }
         })
-}
-
-fn new_index(_table: AnyLuaValue, lua_key: AnyLuaValue, val: AnyLuaValue) -> Result<(), &'static str> {
-    if let LuaString(key) = lua_key {
-        ipc_set(key, val)
-    }
-    else {
-        Err("Invalid key, String expected")
-    }
-}
-
-fn index(_table: AnyLuaValue, lua_key: AnyLuaValue) ->  ValueResult {
-    if let LuaString(key) = lua_key {
-        ipc_get(key)
-    }
-    else {
-        Err("Invalid key, string expected")
-    }
 }
 
 fn init_workspaces(_options: AnyLuaValue) -> Result<(), &'static str> {

--- a/src/lua/tests.rs
+++ b/src/lua/tests.rs
@@ -190,4 +190,3 @@ fn rust_lua_fn(lua: &mut Lua) -> AnyLuaValue {
     assert!(foo.get::<f64, _>("bar").is_some());
     AnyLuaValue::LuaBoolean(true)
 }
-

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -26,6 +26,8 @@ pub const ERR_LOCK_RUNNING: &'static str = "Lua thread: unable to lock RUNNING";
 pub const ERR_LOCK_SENDER: &'static str = "Lua thread: unable to lock SENDER";
 
 const INIT_LUA_FUNC: &'static str = "way_cooler_init";
+const LUA_TERMINATE_CODE: &'static str = "way_cooler.handle_termination()";
+const LUA_RESTART_CODE: &'static str = "way_cooler.handle_restart()";
 
 /// Struct sent to the Lua query
 struct LuaMessage {
@@ -167,7 +169,7 @@ fn handle_message(request: LuaMessage, lua: &mut Lua) -> bool {
     match request.query {
         LuaQuery::Terminate => {
             trace!("Received terminate signal");
-            if let Err(error) = lua.execute::<()>("way_cooler.handle_termination") {
+            if let Err(error) = lua.execute::<()>(LUA_TERMINATE_CODE) {
                 error!("Lua termination callback returned an error: {:?}", error);
             }
             *RUNNING.write().expect(ERR_LOCK_RUNNING) = false;
@@ -178,7 +180,7 @@ fn handle_message(request: LuaMessage, lua: &mut Lua) -> bool {
         },
         LuaQuery::Restart => {
             trace!("Received restart signal!");
-            if let Err(error) = lua.execute::<()>("way_cooler.hanle_termination") {
+            if let Err(error) = lua.execute::<()>(LUA_RESTART_CODE) {
                 error!("Lua restart callback returned an error: {:?}", error);
             }
             *RUNNING.write().expect(ERR_LOCK_RUNNING) = false;

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -22,8 +22,8 @@ lazy_static! {
     pub static ref RUNNING: RwLock<bool> = RwLock::new(false);
 }
 
-const ERR_LOCK_RUNNING: &'static str = "Lua thread: unable to lock RUNNING";
-const ERR_LOCK_SENDER: &'static str = "Lua thread: unable to lock SENDER";
+pub const ERR_LOCK_RUNNING: &'static str = "Lua thread: unable to lock RUNNING";
+pub const ERR_LOCK_SENDER: &'static str = "Lua thread: unable to lock SENDER";
 const INIT_LUA_FUNC: &'static str = "way_cooler_init";
 
 /// Struct sent to the Lua query
@@ -106,7 +106,6 @@ pub fn init() {
     if use_config {
         match maybe_init_file {
             Ok(init_file) => {
-                // TODO defaults here are important
                 let _: () = lua.execute_from_reader(init_file)
                     .expect("Unable to load init file");
                 debug!("Read init.lua successfully");
@@ -183,7 +182,7 @@ fn handle_message(request: LuaMessage, lua: &mut Lua) {
             let _new_handle = thread::Builder::new()
                 .name("Lua re-init".to_string())
                 .spawn(move || {
-                    thread::sleep(Duration::from_secs(4));
+                    //thread::sleep(Duration::from_secs(4));
                     init();
                 });
 


### PR DESCRIPTION
Added ability to restart Way Cooler in place (default keybinding is `<mod>+shift+r`). Reloads the configuration file, including background program arguments, keybindings, and lua function hooks.

* Added `way_cooler_restart` command
  + Not exposed via D-Bus
* Added `way_cooler_restart` lua function hook
  + When Way Cooler is restarted in place, all the code in `way_cooler_restart` is executed
* Added `way_cooler_terminate` lua function hook
  + When Way Cooler is terminated, all the code in `way_cooler_terminate` is executed