### PR TITLE
Updated way-cooler-bg to not specify cursor

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -111,7 +111,7 @@ function way_cooler_init()
   if not status then
     print "Could not find way-cooler-bg! Please install it"
   else
-    os.execute("way-cooler-bg " ..  way_cooler.background .. " ../way-cooler-bg/assets/arrow.png &")
+    os.execute("way-cooler-bg " ..  way_cooler.background)
   end
 end
 

--- a/config/init.lua
+++ b/config/init.lua
@@ -111,7 +111,7 @@ function way_cooler_init()
   if not status then
     print "Could not find way-cooler-bg! Please install it"
   else
-    os.execute("way-cooler-bg " ..  way_cooler.background)
+    os.execute("way-cooler-bg " ..  way_cooler.background .. " &")
   end
 end
 


### PR DESCRIPTION
Latest master of way-cooler-bg no longer requires the cursor, it is compiled in (adds about a megabyte to the binary).

This is a backwards compatible change, but I might as well change the binary call in the config file to not include the old (unnecessary) default argument.