### PR TITLE
Added distribution scripts

### DIFF
--- a/distribute.sh
+++ b/distribute.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+IFS=$'\n\t'
+mkdir dist
+echo "Building Way Cooler..."
+cargo build --release --features static-wlc
+cp target/release/way-cooler dist
+echo "Building Way Cooler Background..."
+(cd ../way-cooler-bg;
+ cargo build --release
+ cp target/release/way-cooler-bg ../way-cooler/dist)
+echo "Bundling install script..."
+cp install.sh dist
+echo "Zipping folder"
+mv dist way-cooler
+tar -cvzf way-cooler.gz way-cooler
+echo "Cleaning up..."
+rm -r way-cooler

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eo pipefail
+IFS=$'\n\t'
+
+function assert_file_exists() {
+    if ! [ -f "$1" ]; then
+        echo -e "\e[31mCould not find file \"$1\", halting...\e[0m"
+        exit 1
+    fi
+}
+
+assert_file_exists "way-cooler"
+assert_file_exists "way-cooler-bg"
+
+if ! [[ $(id -u) = 0 ]] && ! [[ $# == 1 ]]; then
+    echo -e "\e[31m"
+    echo "The install script should be ran as root!"
+    echo -e "\e[0m \e[93m"
+    echo "If you *really* want to install Way Cooler as a user, please pass an install path to this script, like so:"
+    echo -e "\e[0m"
+    echo "./install.sh ~/bin"
+    echo -e "\e[31m"
+    echo "It it highly discouraged to install Way Cooler as your regular user, as it makes it much less secure!"
+    echo -e "\e[0m"
+    exit 1
+fi
+
+install_path=$1;
+: ${install_path:='/usr/bin'}
+[ -d $install_path ] || mkdir $install_path
+
+cp way-cooler $install_path
+cp way-cooler-bg $install_path
+
+chown $USER $install_path/way-cooler
+chgrp $USER $install_path/way-cooler
+chown $USER $install_path/way-cooler-bg
+chgrp $USER $install_path/way-cooler-bg
+
+if ! [[ $(pidof systemd) ]] && [[ $(id -u) = 0 ]]; then
+    echo "systemd is not installed on this machine, activating the setuid bit on $install_path/way-cooler"
+    chmod u+s $install_path/way-cooler
+fi
+
+echo -e "\e[32mWay Cooler has been installed on your system\e[0m"

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ assert_file_exists "way-cooler-bg"
 
 if ! [[ $(id -u) = 0 ]] && ! [[ $# == 1 ]]; then
     echo -e "\e[31m"
-    echo "The install script should be ran as root!"
+    echo "The install script should be run as root!"
     echo -e "\e[0m \e[93m"
     echo "If you *really* want to install Way Cooler as a user, please pass an install path to this script, like so:"
     echo -e "\e[0m"


### PR DESCRIPTION
* Added `distribute.sh`, sets up a gzip for distributing way cooler. It is very platform specific, because it requires the machine to have a static version of the wlc library, and way-cooler-bg on the machine as well. It zips up:
  - `way-cooler`
  - `way-cooler-bg` 
  - `install.sh`
* Added `install.sh`, script to install Way Cooler on user's machine.
  - Gives error text if ran without root, but gives an option for recourse if that's what they _really_ want to do.