### PR TITLE
Updated Way Cooler version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "way-cooler"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "way-cooler"
 description = "Customizeable Wayland compositor written in Rust"
-version = "0.4.0"
+version = "0.4.1"
 repository = "https://github.com/Immington-Industries/way-cooler/"
 keywords = ["Wayland", "compositor", "window", "manager", "wlc"]
 readme = "README.md"


### PR DESCRIPTION
* In place restart, allowing you to reload the config file without restarting Way Cooler
* Fixes to tiling, including popup menus and resizing.
* Init file is now compiled into Way Cooler, and will default to that if a config file could not be found on the system.
* Wrote the beginning of the distribution scripts, which will be used to distribute binary versions of Way Cooler with wlc statically linked.