### PR TITLE
let kill-way-cooler command be rebindable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Way Cooler was started by @Timidger and @SnirkImmington, but these fine people h
 - @starfys created way-cooler desktop file
 - @toogley fixed a link
 - @paulmenzel fixed a typo
+- @thefarwind made kill way-cooler command rebindable
 
 And of course, thanks to the Rust community and the developers of [wlc].
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -327,6 +327,7 @@ pub extern fn compositor_ready() {
     info!("Preparing compositor!");
     info!("Initializing Lua...");
     lua::init();
+    keys::init();
 }
 
 pub extern fn compositor_terminating() {

--- a/src/commands/defaults.rs
+++ b/src/commands/defaults.rs
@@ -23,7 +23,7 @@ pub fn register_defaults() {
         coms.insert(name.to_string(), val);
     };
 
-    register("quit", Arc::new(quit));
+    register("way_cooler_quit", Arc::new(way_cooler_quit));
     register("launch_terminal", Arc::new(launch_terminal));
     register("launch_dmenu", Arc::new(launch_dmenu));
     register("print_pointer", Arc::new(print_pointer));
@@ -138,7 +138,7 @@ fn print_pointer() {
         .expect("Error telling Lua to get pointer coords");
 }
 
-fn quit() {
+fn way_cooler_quit() {
     info!("Closing way cooler!!");
     ::rustwlc::terminate();
 }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -46,19 +46,18 @@ pub fn keymod_from_names(keys: &[&str]) -> Result<KeyMod, String> {
 pub fn init() {
     use rustwlc::xkb::keysyms;
     use commands;
-    register(KeyPress::new(MOD_ALT | MOD_SHIFT, keysyms::KEY_Escape),
-             KeyEvent::Command(commands::get("quit")
-                               .expect("Error reading commands::quit")));
+    if !is_quit_bound() {
+        register(KeyPress::new(MOD_ALT | MOD_SHIFT, keysyms::KEY_Escape),
+                 KeyEvent::Command(commands::get("way_cooler_quit")
+                                   .expect("Error reading commands::way_cooler_quit")));
+    }
 }
 
 /// Clears all the keys from Way Cooler's memory.
 pub fn clear_keys() {
-    {
-        let mut bindings = BINDINGS.write()
-            .expect("Keybindings/clear_keys: unable to lock keybindings");
-        bindings.drain();
-    }
-    init();
+    let mut bindings = BINDINGS.write()
+        .expect("Keybindings/clear_keys: unable to lock keybindings");
+    bindings.drain();
 }
 
 /// Get a key mapping from the list.
@@ -73,6 +72,25 @@ pub fn register(key: KeyPress, event: KeyEvent) -> Option<KeyEvent> {
     let mut bindings = BINDINGS.write()
         .expect("Keybindings/register: unable to lock keybindings");
     bindings.insert(key, event)
+}
+
+/// Determine if the way_cooler_quit command is already bound
+pub fn is_quit_bound() -> bool {
+    use commands;
+
+    let bindings = BINDINGS.read()
+        .expect("Keybindings/get: unable to lock keybindings");
+    let quit = commands::get("way_cooler_quit")
+        .expect("Error reading commands::way_cooler_quit");
+
+    for value in bindings.values() {
+        if let KeyEvent::Command(ref cmd) = *value {
+            if (&**cmd as *const _) == (&*quit as *const _) {
+                return true;
+            }
+        }
+    };
+    false
 }
 
 #[cfg(test)]

--- a/src/lua/thread.rs
+++ b/src/lua/thread.rs
@@ -13,6 +13,7 @@ use hlua::{Lua, LuaError, functions_read};
 use super::types::*;
 use super::rust_interop;
 use super::init_path;
+use super::super::keys;
 
 lazy_static! {
     /// Sends requests to the Lua thread
@@ -193,6 +194,7 @@ fn handle_message(request: LuaMessage, lua: &mut Lua) -> bool {
                 .name("Lua re-init".to_string())
                 .spawn(move || {
                     init();
+                    keys::init();
                 });
 
             info!("Lua thread restarting");

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,6 @@ fn main() {
     callbacks::init();
     commands::init();
     registry::init();
-    keys::init();
     ipc::init();
 
     info!("Running wlc...");


### PR DESCRIPTION
#### Summary of Changes

This was resolved by adding a set to track the command names (as strings). when keys::init is called, it checks to see whether the "quit" command has been bound, and if so, does not bind it.

Part of this involved changing when keys::init was called, so that it would occur after lua::init was called. That way it could be determined whether alt-shift-esc needed to be bound or not. 

#### Testing

The changes were tested as follows. No software tests were added, since the meat of this functionality relied on how the software behaved on start up.

1. Ran way-cooler with default init file.
2. Verified way-cooler closed with alt-shift-esc.
3. Ran way-cooler again.
4. Entered way-cooler restart command (alt-shift-r)
5. Verified way-cooler closed with alt-shift-esc.
6. Added 'alt-shift-d' quit command to init file and started way-cooler.
7. Verified 'alt-shift-esc' did not kill way-cooler.
8. Verified 'alt-shift-d' killed way-cooler.
9. Ran way-cooler again.
10. Entered way-cooler restart command (alt-shift-r)
11. Verified 'alt-shift-esc' did not kill way-cooler.
12. Verified 'alt-shift-d' killed way-cooler.

#### Alternative Solutions and Modifications

Alternative solutions would be to have the set be for the CommandFn, which could then be compared by `(&*cmd0 as *const _) == (&*cmd1 as *const _)`, or instead of having a set, loop through the KeyEvents to check for this specific message.

Currently the set_bound is separate from the register function, which means when binding a command the programmer needs to remember to call both functions. It would make sense to create a separate register function which took a function name as a string, looked up the command with the string, and then added the string to the bound_commands set.

#### Commit message:

added bound_commands set to keep track of command strings which have key bindings. Added set and is function to add items to to the bound commands set. Added commands set by the lua script to the bound commands. modified keys::init to check whether the quit command is bound, and if so, not bind alt-shift-esc to quit. Moved keys::init to be called after the completion of lua::init calls.

this should resolve #172 