### PR TITLE
Can rebind mouse modifier, Fixes #176

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -105,6 +105,9 @@ for _, key in pairs(keys) do
     config.register_key(key)
 end
 
+-- Register the mod key to also be the mod key for mouse commands
+config.register_mouse_modifier(mod)
+
 function cleanup_background()
   os.execute("pkill way-cooler-bg")
 end

--- a/lib/lua/lua_init.lua
+++ b/lib/lua/lua_init.lua
@@ -65,6 +65,11 @@ config_table.register_key = function(key)
         error("keybinding action: expected string or a function"..use_key, 2)
     end
 end
+-- Bind a key to use in conjunction with the mouse for certain commands (resize, move floating)
+config_table.register_mouse_modifier = function(mod)
+  assert(type(mod) == 'string', "mod: expected a string")
+  rust.register_mouse_modifier(mod)
+end
 -- Register callback to execute on restart
 way_cooler_table.on_restart = function(callback)
     assert(callback, "missing callback")

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -5,7 +5,7 @@
 use rustwlc::handle::{WlcOutput, WlcView};
 use rustwlc::types::{ButtonState, KeyboardModifiers, KeyState, KeyboardLed, ScrollAxis, Size,
                      Point, Geometry, ResizeEdge, ViewState, VIEW_ACTIVATED, VIEW_RESIZING,
-                     MOD_NONE, MOD_CTRL, RESIZE_LEFT, RESIZE_RIGHT, RESIZE_TOP, RESIZE_BOTTOM};
+                     MOD_NONE, RESIZE_LEFT, RESIZE_RIGHT, RESIZE_TOP, RESIZE_BOTTOM};
 use rustwlc::input::{pointer, keyboard};
 
 use super::keys::{self, KeyPress, KeyEvent};
@@ -196,13 +196,14 @@ pub extern fn pointer_button(view: WlcView, _time: u32,
                          mods: &KeyboardModifiers, button: u32,
                              state: ButtonState, point: &Point) -> bool {
     if state == ButtonState::Pressed {
+        let mouse_mod = keys::mouse_modifier();
         if button == LEFT_CLICK && !view.is_root() {
             if let Ok(mut tree) = try_lock_tree() {
                 tree.set_active_view(view).unwrap_or_else(|_| {
                     // still focus on view, even if not in tree.
                     view.focus();
                 });
-                if mods.mods.contains(MOD_CTRL) {
+                if mods.mods.contains(mouse_mod) {
                     let action = Action {
                         view: view,
                         grab: *point,
@@ -216,7 +217,7 @@ pub extern fn pointer_button(view: WlcView, _time: u32,
                 tree.set_active_view(view).ok();
             }
             // TODO Make this set in the config file and read here.
-            if mods.mods.contains(MOD_CTRL) {
+            if mods.mods.contains(mouse_mod) {
                 let action = Action {
                     view: view,
                     grab: *point,

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -23,7 +23,7 @@ lazy_static! {
         map
     };
 
-    static ref MOUSE_MODIFIER: RwLock<KeyMod> = RwLock::new(MOD_ALT);
+    static ref MOUSE_MODIFIER: RwLock<KeyMod> = RwLock::new(MOD_CTRL);
 }
 
 /// Parses a KeyMod from key names.

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -22,6 +22,8 @@ lazy_static! {
         map.insert("\t", "tab");
         map
     };
+
+    static ref MOUSE_MODIFIER: RwLock<KeyMod> = RwLock::new(MOD_ALT);
 }
 
 /// Parses a KeyMod from key names.
@@ -67,11 +69,25 @@ pub fn get(key: &KeyPress) -> Option<KeyEvent> {
     bindings.get(key).map(KeyEvent::clone)
 }
 
+/// Gets the current key modifier for mouse control
+pub fn mouse_modifier() -> KeyMod {
+    let key_mod = MOUSE_MODIFIER.read()
+        .expect("Keybindings/register_mouse_modifier: unable to lock MOUSE MODIFIER");
+    *key_mod
+}
+
 /// Register a new set of key mappings
 pub fn register(key: KeyPress, event: KeyEvent) -> Option<KeyEvent> {
     let mut bindings = BINDINGS.write()
         .expect("Keybindings/register: unable to lock keybindings");
     bindings.insert(key, event)
+}
+
+/// Registers a modifier to be used with mouse commands
+pub fn register_mouse_modifier(modifier: KeyMod) {
+    let mut key_mod = MOUSE_MODIFIER.write()
+        .expect("Keybindings/register_mouse_modifier: unable to lock MOUSE MODIFIER");
+    *key_mod = modifier;
 }
 
 /// Determine if the way_cooler_quit command is already bound

--- a/src/lua/rust_interop.rs
+++ b/src/lua/rust_interop.rs
@@ -25,6 +25,7 @@ pub fn register_libraries(lua: &mut Lua) {
         rust_table.set("init_workspaces", hlua::function1(init_workspaces));
         rust_table.set("register_lua_key", hlua::function2(register_lua_key));
         rust_table.set("register_command_key", hlua::function3(register_command_key));
+        rust_table.set("register_mouse_modifier", hlua::function1(register_mouse_modifier));
         rust_table.set("keypress_index", hlua::function1(keypress_index));
         rust_table.set("ipc_run", hlua::function1(ipc_run));
         rust_table.set("ipc_get", hlua::function1(ipc_get));
@@ -90,6 +91,13 @@ fn ipc_set(key: String, value: AnyLuaValue) -> Result<(), &'static str> {
 
 fn init_workspaces(_options: AnyLuaValue) -> Result<(), &'static str> {
     error!("Attempting to call `init_workspaces`, this is not implemented");
+    Ok(())
+}
+
+/// Registers a modifier to be used in conjunction with mouse commands
+fn register_mouse_modifier(modifier: String) -> Result<(), String> {
+    let modifier = try!(keys::keymod_from_names(&[modifier.as_str()]));
+    keys::register_mouse_modifier(modifier);
     Ok(())
 }
 


### PR DESCRIPTION
* Added new command to config file -- `config.register_mouse_modifier`

This is a backwards compatible change.

By default, if `register_mouse_modifier` is not called it defaults to the previous modifier -- left control. With the new configuration file, it changes it to be `alt`, which is the default modifier for the other commands as well.