### PR TITLE
Background resizes with output

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -68,13 +68,13 @@ pub extern fn view_created(view: WlcView) -> bool {
             size: resolution
         };
         view.set_geometry(ResizeEdge::empty(), fullscreen);
-        return true
+        if let Ok(mut tree) = try_lock_tree() {
+            return tree.add_background(view).is_ok();
+        }
+        return false
     }
     if let Ok(mut tree) = try_lock_tree() {
         tree.add_view(view).and_then(|_| {
-            if view.get_class() == "Background" {
-                return Ok(())
-            }
             view.set_state(VIEW_MAXIMIZED, true);
             tree.set_active_view(view).or_else(|_| {
                 // We still want to focus on the window that appeared

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -69,7 +69,8 @@ pub extern fn view_created(view: WlcView) -> bool {
         };
         view.set_geometry(ResizeEdge::empty(), fullscreen);
         if let Ok(mut tree) = try_lock_tree() {
-            return tree.add_background(view).is_ok();
+            let outputs = tree.outputs();
+            return tree.add_background(view, outputs.as_slice()).is_ok();
         }
         return false
     }

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -1,0 +1,39 @@
+//! A collection of methods that modify the background of the outputs.
+use super::super::{Container, ContainerType, LayoutTree, TreeError};
+use super::super::commands::CommandResult;
+
+use uuid::Uuid;
+use rustwlc::{WlcView};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BackgroundErr {
+    /// A background (the `WlcView`) is already attached to the output (`UUID`)
+    AlreadyAttached(Uuid, WlcView)
+}
+
+impl LayoutTree {
+    /// Attempts to attach the `bg` to the `outputs`.
+    ///
+    /// If any of them already have a background attached,
+    /// ``
+    pub fn attach_background(&mut self, bg: WlcView, outputs: &[Uuid])
+                             -> CommandResult {
+        for output_id in outputs {
+            match *try!(self.lookup_mut(*output_id)) {
+                Container::Output { ref mut background, .. } => {
+                    if background.is_none() {
+                        *background = Some(bg);
+                    } else {
+                        error!("HERE");
+                        error!("{:?}", background.clone());
+                        return Err(TreeError::Background(
+                            BackgroundErr::AlreadyAttached(*output_id, background.clone().unwrap())))
+                    }
+                },
+                _ => return Err(TreeError::UuidWrongType(*output_id,
+                                                         vec![ContainerType::Output]))
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/layout/actions/background.rs
+++ b/src/layout/actions/background.rs
@@ -5,6 +5,8 @@ use super::super::commands::CommandResult;
 use uuid::Uuid;
 use rustwlc::{WlcView};
 
+use std::collections::HashSet;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BackgroundErr {
     /// A background (the `WlcView`) is already attached to the output (`UUID`)
@@ -18,21 +20,31 @@ impl LayoutTree {
     /// ``
     pub fn attach_background(&mut self, bg: WlcView, outputs: &[Uuid])
                              -> CommandResult {
+        // TODO Remove this to remove when the wlc bug is fixed
+        // https://github.com/Cloudef/wlc/issues/221
+        let mut to_remove = HashSet::with_capacity(outputs.len());
         for output_id in outputs {
             match *try!(self.lookup_mut(*output_id)) {
                 Container::Output { ref mut background, .. } => {
                     if background.is_none() {
                         *background = Some(bg);
                     } else {
-                        error!("HERE");
-                        error!("{:?}", background.clone());
-                        return Err(TreeError::Background(
-                            BackgroundErr::AlreadyAttached(*output_id, background.clone().unwrap())))
+                        // TODO This can't be used right now, see this bug:
+                        // https://github.com/Cloudef/wlc/issues/221
+                        /*return Err(TreeError::Background(
+                            BackgroundErr::AlreadyAttached(*output_id, background.clone().unwrap())))*/
+                        if let Some(view) = background.take() {
+                            to_remove.insert(view);
+                        }
+                        *background = Some(bg);
                     }
                 },
                 _ => return Err(TreeError::UuidWrongType(*output_id,
                                                          vec![ContainerType::Output]))
             }
+        }
+        for view in to_remove {
+            view.close();
         }
         Ok(())
     }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -28,15 +28,21 @@ impl LayoutTree {
                 }
             }
             ContainerType::Output => {
-                let handle = match self.tree[node_ix] {
-                    Container::Output { ref handle, .. } => handle.clone(),
+                let geometry = match self.tree[node_ix] {
+                    Container::Output { ref handle, ref mut background, .. } => {
+                        let size = handle.get_resolution()
+                            .expect("Couldn't get resolution");
+                        let geometry = Geometry {
+                            origin: Point { x: 0, y: 0 },
+                            size: size
+                        };
+                        // update the background size
+                        if let Some(background) = *background {
+                            background.set_geometry(ResizeEdge::empty(), geometry)
+                        }
+                        geometry
+                    },
                     _ => unreachable!()
-                };
-                let size = handle.get_resolution()
-                    .expect("Couldn't get resolution");
-                let geometry = Geometry {
-                    origin: Point { x: 0, y: 0 },
-                    size: size
                 };
                 for workspace_ix in self.tree.children_of(node_ix) {
                     self.layout_helper(workspace_ix, geometry.clone());

--- a/src/layout/actions/mod.rs
+++ b/src/layout/actions/mod.rs
@@ -4,3 +4,4 @@ pub mod focus;
 pub mod workspace;
 pub mod resize;
 pub mod pointer;
+pub mod background;

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -8,8 +8,6 @@ use uuid::Uuid;
 use rustwlc::{Point, ResizeEdge, WlcView, WlcOutput, ViewType};
 use rustc_serialize::json::{Json, ToJson};
 
-use std::collections::HashSet;
-
 pub type CommandResult = Result<(), TreeError>;
 
 /* These commands are exported to take nothing and return nothing,
@@ -250,20 +248,15 @@ impl Tree {
     /// If there was a previous background, it is removed and deallocated.
     pub fn add_background(&mut self, view: WlcView) -> CommandResult {
         let outputs = self.0.tree.children_of(self.0.tree.root_ix());
-        let mut to_remove = HashSet::with_capacity(outputs.len());
         for output_ix in outputs {
             match self.0.tree[output_ix] {
                 Container::Output { ref mut background, .. } => {
-                    if let Some(view) = background.take() {
-                        to_remove.insert(view);
+                    if background.is_none() {
+                        *background = Some(view);
                     }
-                    *background = Some(view);
                 },
                 _ => unreachable!()
             }
-        }
-        for view in to_remove {
-            view.close();
         }
         Ok(())
     }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -255,21 +255,7 @@ impl Tree {
     ///
     /// If there was a previous background, it is removed and deallocated.
     pub fn add_background(&mut self, view: WlcView, outputs: &[Uuid]) -> CommandResult {
-        for output_id in outputs {
-            match *try!(self.0.lookup_mut(*output_id)) {
-                Container::Output { ref mut background, .. } => {
-                    if background.is_none() {
-                        *background = Some(view);
-                    } else {
-                        // TODO error handling :P
-                        panic!()
-                    }
-                },
-                _ => return Err(TreeError::UuidWrongType(*output_id,
-                                                         vec![ContainerType::Output]))
-            }
-        }
-        Ok(())
+        self.0.attach_background(view, outputs)
     }
 
     /// Adds a Workspace to the tree. Never fails

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -239,8 +239,7 @@ impl Tree {
 
     /// Adds an Output to the tree. Never fails
     pub fn add_output(&mut self, output: WlcOutput) -> CommandResult {
-        self.0.add_output(output);
-        Ok(())
+        self.0.add_output(output)
     }
 
     /// Gets a list of UUIDs for all the outputs, in the order they were added.

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -59,6 +59,8 @@ pub enum Container {
     Output {
         /// Handle to the wlc
         handle: WlcOutput,
+        /// Optional background for the output
+        background: Option<WlcView>,
         /// UUID associated with container, client program can use container
         id: Uuid,
     },
@@ -103,6 +105,7 @@ impl Container {
     pub fn new_output(handle: WlcOutput) -> Container {
         Container::Output {
             handle: handle,
+            background: None,
             id: Uuid::new_v4()
         }
     }

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -864,8 +864,8 @@ pub mod tests {
     #[test]
     fn add_output_test() {
         let mut tree = basic_tree();
-        let new_output = WlcView::root().as_output();
-        tree.add_output(new_output);
+        let new_output = WlcView::dummy(2).as_output();
+        tree.add_output(new_output).expect("Couldn't add output");
         let output_ix = tree.active_ix_of(ContainerType::Output).unwrap();
         let handle = match tree.tree[output_ix].get_handle().unwrap() {
             Handle::Output(output) => output,

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -324,6 +324,17 @@ impl LayoutTree {
             self.validate();
             Ok(container)
         } else {
+            // Check if it's a background, and if so invalidate it
+            for output_ix in self.tree.children_of(self.tree.root_ix()) {
+                match self.tree[output_ix] {
+                    Container::Output { ref mut background, .. } => {
+                        if Some(*view) == *background {
+                            background.take();
+                        }
+                    },
+                    _ => unreachable!()
+                }
+            }
             self.validate();
             Err(TreeError::ViewNotFound(view.clone()))
         }

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -12,6 +12,7 @@ use super::super::actions::focus::FocusError;
 use super::super::actions::movement::MovementError;
 use super::super::actions::layout::LayoutErr;
 use super::super::actions::resize::ResizeErr;
+use super::super::actions::background::BackgroundErr;
 
 
 use super::super::core::graph_tree::GraphError;
@@ -96,6 +97,9 @@ pub enum TreeError {
     Layout(LayoutErr),
     /// An error occurred while trying to resize the layout
     Resize(ResizeErr),
+    /// An error occurred while trying to do something with the background
+    /// of an output
+    Background(BackgroundErr),
     /// An error occurred while attempting to modify or use the main action
     Action(ActionErr),
     /// The tree was (true) or was not (false) performing an action,


### PR DESCRIPTION
* Backgrounds are now stored in `Output` containers
* Background are part of the layout code, and will now resize properly when the output size changes.
* ~If a new background is added while an old one still exists, the previous one is now killed. This is **not** a security issue, because hypothetically when security is actually implemented clients would never get this far. This is subject to change however.~
  + ~I realized this is stupid. If a background needs to be replaced, that client should instead be killed. Currently, there is no mechanism to do this from Way Cooler (and may never be). Instead, if a background needs to be replaced then there needs to be coordination done with the program that provides the background.~
    + There's currently [a bug with wlc / wayland](https://github.com/Cloudef/wlc/issues/221) that's causing a segfault if the background is denied creation...going to revert the changes I made and keep the original functionality instead.
* Outputs are no longer added if they are already present in the tree
  + This improves memory consumption (switching TTYs no longer just keeps allocating more and more memory)
  + As a consequence of this, switching to a different TTY and switching back to Way Cooler will no longer cause it to switch to the first workspace.