### PR TITLE
Added disable-debug feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ dummy-rustwlc = "0.5.1"
 
 [features]
 static-wlc = ["rustwlc/static-wlc"]
+disable-debug = []

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -6,6 +6,7 @@ use rustwlc::{Geometry, Point, Size, ResizeEdge};
 use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
 use super::super::core::container::{Container, ContainerType, Layout};
+use ::debug_enabled;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -510,7 +511,7 @@ impl LayoutTree {
     pub fn normalize_container(&mut self, node_ix: NodeIndex) {
         // if floating, do not normalize
         if self.tree[node_ix].floating() {
-            if cfg!(debug_assertions) || !cfg!(disable_debug) {
+            if cfg!(debug_assertions) || !debug_enabled() {
                 error!("Tried to normalize {:?}\n{:#?}", node_ix, self);
                 panic!("Tried to normalize a floating view, are you sure you want to do that?")
             } else {

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -510,7 +510,7 @@ impl LayoutTree {
     pub fn normalize_container(&mut self, node_ix: NodeIndex) {
         // if floating, do not normalize
         if self.tree[node_ix].floating() {
-            if cfg!(debug_assertions) {
+            if cfg!(debug_assertions) || !cfg!(disable_debug) {
                 error!("Tried to normalize {:?}\n{:#?}", node_ix, self);
                 panic!("Tried to normalize a floating view, are you sure you want to do that?")
             } else {

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 use rustwlc::{Geometry, Point};
 use super::super::LayoutTree;
 use super::super::core::container::{Container, ContainerType};
+use ::debug_enabled;
 
 // TODO This module needs to be updated like the other modules...
 // Need to add some errors for this (such as when trying to move a non-container/view,
@@ -182,7 +183,7 @@ impl LayoutTree {
 
             // Get the root container of the next workspace
             let next_work_children = self.tree.children_of(next_work_ix);
-            if cfg!(debug_assertions) || !cfg!(disable_debug) {
+            if cfg!(debug_assertions) || !debug_enabled() {
                 assert!(next_work_children.len() == 1,
                         "Next workspace has multiple roots!");
             }

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -182,7 +182,7 @@ impl LayoutTree {
 
             // Get the root container of the next workspace
             let next_work_children = self.tree.children_of(next_work_ix);
-            if cfg!(debug_assertions) {
+            if cfg!(debug_assertions) || !cfg!(disable_debug) {
                 assert!(next_work_children.len() == 1,
                         "Next workspace has multiple roots!");
             }

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use rustwlc::WlcView;
 
 use super::path::{Path, PathBuilder};
+use ::debug_enabled;
 
 use layout::{Container, ContainerType, Handle};
 
@@ -509,7 +510,7 @@ impl InnerTree {
         let mut neighbors = self.graph
             .neighbors_directed(node_ix, EdgeDirection::Incoming);
         let result = neighbors.next().ok_or(GraphError::NoParent(node_ix));
-        if cfg!(debug_assertions) || !cfg!(disable_debug) {
+        if cfg!(debug_assertions) || !debug_enabled() {
             if neighbors.next().is_some() {
                 error!("{:?}", self);
                 panic!("parent_of: node has multiple parents!")

--- a/src/layout/core/graph_tree.rs
+++ b/src/layout/core/graph_tree.rs
@@ -509,7 +509,7 @@ impl InnerTree {
         let mut neighbors = self.graph
             .neighbors_directed(node_ix, EdgeDirection::Incoming);
         let result = neighbors.next().ok_or(GraphError::NoParent(node_ix));
-        if cfg!(debug_assertions) {
+        if cfg!(debug_assertions) || !cfg!(disable_debug) {
             if neighbors.next().is_some() {
                 error!("{:?}", self);
                 panic!("parent_of: node has multiple parents!")

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -478,7 +478,7 @@ impl LayoutTree {
     }
 
     /// Validates the tree
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, not(disable_debug)))]
     pub fn validate(&self) {
         // Recursive method to ensure child/parent nodes are connected
         fn validate_node_connections(this: &LayoutTree, parent_ix: NodeIndex) {
@@ -574,7 +574,7 @@ impl LayoutTree {
     }
 
     /// Validates the tree
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, disable_debug))]
     pub fn validate_path(&self) {
         // Ensure there is only one active path from the root
         let mut next_ix = Some(self.tree.root_ix());
@@ -613,10 +613,10 @@ impl LayoutTree {
         }
     }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(all(not(debug_assertions), not(disable_debug)))]
     pub fn validate(&self) {}
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(all(not(debug_assertions), not(disable_debug)))]
     pub fn validate_path(&self) {}
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,12 @@ fn detect_proprietary() {
     }
 }
 
+#[inline(always)]
+/// Determines if we should build with debug symbols.
+pub fn debug_enabled() -> bool {
+    cfg!(not(disable_debug))
+}
+
 /// Initializes the logging system.
 pub fn init_logs() {
     let mut builder = env_logger::LogBuilder::new();


### PR DESCRIPTION
* Added `disable-debug` feature. 
  + Disables debug checks in Way Cooler. Not recommended, though it will improve performance.
  + When we reach 1.0, this feature will be replaced with a `enable-debug`, which will do the opposite (enable debug checks with present)

Fixes #202 