### PR TITLE
Logging improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["Wayland", "compositor", "window", "manager", "wlc"]
 readme = "README.md"
 license = "MIT"
 authors = ["Snirk Immington <snirk.immington@gmail.com>", "Timidger <apragmaticplace@gmail.com>"]
+build = "build.rs"
 
 [dependencies]
 rustwlc = "0.5.3"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::process::Command;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    dump_git_version();
+}
+
+/// Writes the current git hash to a file that is read by Way Cooler
+///
+/// If this is a release build, the file will be empty.
+fn dump_git_version() {
+    if let Some(git_version) = git_version() {
+        let out_dir = env::var("OUT_DIR")
+            .expect("Could not find out directory!");
+        let dest_path = Path::new(&out_dir).join("git-version.txt");
+        let mut f = File::create(&dest_path)
+            .expect("Could not write git version to out directory");
+
+        f.write_all(git_version.as_ref())
+            .expect("Could not write to git version file");
+    }
+}
+
+/// Gets the current hash of HEAD. Returns None if for some reason
+/// that could not be retrieved (e.g not in a git repository)
+fn git_version() -> Option<String> {
+    Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .ok()
+        .map(|output| output.stdout)
+        .map(|hash| String::from_utf8_lossy(&hash).trim().into())
+}

--- a/build.rs
+++ b/build.rs
@@ -12,13 +12,12 @@ fn main() {
 ///
 /// If this is a release build, the file will be empty.
 fn dump_git_version() {
+    let out_dir = env::var("OUT_DIR")
+        .expect("Could not find out directory!");
+    let dest_path = Path::new(&out_dir).join("git-version.txt");
+    let mut f = File::create(&dest_path)
+        .expect("Could not write git version to out directory");
     if let Some(git_version) = git_version() {
-        let out_dir = env::var("OUT_DIR")
-            .expect("Could not find out directory!");
-        let dest_path = Path::new(&out_dir).join("git-version.txt");
-        let mut f = File::create(&dest_path)
-            .expect("Could not write git version to out directory");
-
         f.write_all(git_version.as_ref())
             .expect("Could not write to git version file");
     }
@@ -27,11 +26,27 @@ fn dump_git_version() {
 /// Gets the current hash of HEAD. Returns None if for some reason
 /// that could not be retrieved (e.g not in a git repository)
 fn git_version() -> Option<String> {
-    Command::new("git")
-        .arg("rev-parse")
+    if !in_release_commit() {
+        Command::new("git")
+            .arg("rev-parse")
+            .arg("HEAD")
+            .output()
+            .ok()
+            .map(|output| output.stdout)
+            .map(|hash| String::from_utf8_lossy(&hash).trim().into())
+    } else {
+        None
+    }
+}
+
+
+/// Determines if the current HEAD is tagged with a release
+fn in_release_commit() -> bool {
+    let result = Command::new("git")
+        .arg("describe")
+        .arg("--exact-match")
+        .arg("--tags")
         .arg("HEAD")
-        .output()
-        .ok()
-        .map(|output| output.stdout)
-        .map(|hash| String::from_utf8_lossy(&hash).trim().into())
+        .output().unwrap();
+    result.status.success()
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -55,9 +55,9 @@ pub extern fn output_resolution(output: WlcOutput,
 }
 
 pub extern fn view_created(view: WlcView) -> bool {
-    trace!("view_created: {:?}: \"{}\"", view, view.get_title());
+    debug!("view_created: {:?}: \"{}\"", view, view.get_title());
     if view.get_class().as_str() == "Background" {
-        info!("Setting background: {}", view.get_title());
+        debug!("Setting background: {}", view.get_title());
         view.send_to_back();
         view.set_mask(1);
         let output = view.get_output();
@@ -164,7 +164,7 @@ pub extern fn keyboard_key(_view: WlcView, _time: u32, mods: &KeyboardModifiers,
 
     if state == KeyState::Pressed {
         if let Some(action) = keys::get(&press) {
-            debug!("[key] Found an action for {}", press);
+            info!("[key] Found an action for {}, blocking event", press);
             match action {
                 KeyEvent::Command(func) => {
                     func();
@@ -199,6 +199,7 @@ pub extern fn pointer_button(view: WlcView, _time: u32,
     if state == ButtonState::Pressed {
         let mouse_mod = keys::mouse_modifier();
         if button == LEFT_CLICK && !view.is_root() {
+            info!("User left clicked w/ mods \"{:?}\" on {:?}", mods, view);
             if let Ok(mut tree) = try_lock_tree() {
                 tree.set_active_view(view).unwrap_or_else(|_| {
                     // still focus on view, even if not in tree.
@@ -214,10 +215,10 @@ pub extern fn pointer_button(view: WlcView, _time: u32,
                 }
             }
         } else if button == RIGHT_CLICK && !view.is_root() {
+            info!("User right clicked w/ mods \"{:?}\" on {:?}", mods, view);
             if let Ok(mut tree) = try_lock_tree() {
                 tree.set_active_view(view).ok();
             }
-            // TODO Make this set in the config file and read here.
             if mods.mods.contains(mouse_mod) {
                 let action = Action {
                     view: view,
@@ -262,6 +263,13 @@ pub extern fn pointer_button(view: WlcView, _time: u32,
         }
     } else {
         if let Ok(lock) = try_lock_action() {
+            let unknown = format!("unknown ({})", button);
+            info!("User released {:?} mouse button",
+                  match button {
+                      RIGHT_CLICK => "right",
+                      LEFT_CLICK => "left",
+                      _ => unknown.as_str()
+                  });
             match *lock {
                 Some(action) => {
                     let view = action.view;

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -80,6 +80,7 @@ pub fn mouse_modifier() -> KeyMod {
 pub fn register(key: KeyPress, event: KeyEvent) -> Option<KeyEvent> {
     let mut bindings = BINDINGS.write()
         .expect("Keybindings/register: unable to lock keybindings");
+    trace!("Registering {} for {:?}", key, event);
     bindings.insert(key, event)
 }
 

--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -183,11 +183,11 @@ impl LayoutTree {
                 .expect("Could not set active container");
             match self.tree[new_active_ix] {
                 Container::View { ref handle, .. } => {
-                    info!("Focusing on {:?}", handle);
+                    debug!("Focusing on {:?}", handle);
                     handle.focus();
                 },
                 Container::Container { .. } => {
-                    info!("No view found, focusing on nothing in workspace {:?}", parent_ix);
+                    debug!("No view found, focusing on nothing in workspace {:?}", parent_ix);
                     WlcView::root().focus();
                 }
                 _ => unreachable!()
@@ -200,7 +200,7 @@ impl LayoutTree {
                                                                     ContainerType::View) {
                     match self.tree[view_ix] {
                         Container::View { handle, id, .. } => {
-                            info!("Floating view found, focusing on {:#?}", handle);
+                            debug!("Floating view found, focusing on {:#?}", handle);
                             handle.focus();
                             self.set_active_container(id)
                                 .expect("Could not set active container");

--- a/src/layout/actions/workspace.rs
+++ b/src/layout/actions/workspace.rs
@@ -189,7 +189,7 @@ impl LayoutTree {
             let next_work_root_ix = next_work_children[0];
 
             // Move the container
-            info!("Moving container {:?} to workspace {}",
+            debug!("Moving container {:?} to workspace {}",
                 self.get_active_container(), name);
             self.tree.move_node(active_ix, next_work_root_ix);
 

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -158,7 +158,7 @@ impl LayoutTree {
     /// Sets the active container to be the given node.
     pub fn set_active_node(&mut self, node_ix: NodeIndex) -> CommandResult {
         if self.active_container != Some(node_ix) {
-            info!("Active container was {}, is now {}",
+            debug!("Active container was {}, is now {}",
                   self.active_container.map(|node| node.index().to_string())
                     .unwrap_or("not set".into()),
                   node_ix.index());

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,12 @@ pub fn init_logs() {
     info!("Logger initialized, setting wlc handlers.");
 }
 
+fn log_environment() {
+    for (key, value) in env::vars() {
+        debug!("{}: {}", key, value);
+    }
+}
+
 /// Handler for signals
 extern "C" fn sig_handle(_: nix::libc::c_int) {
     rustwlc::terminate();
@@ -159,6 +165,7 @@ fn main() {
     unsafe {signal::sigaction(signal::SIGINT, &sig_action).unwrap() };
 
     init_logs();
+    log_environment();
     detect_proprietary();
     // This prepares wlc, doesn't run main loop until run_wlc is called
     let run_wlc = rustwlc::init2().expect("Unable to initialize wlc!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ use nix::sys::signal::{self, SigHandler, SigSet, SigAction, SaFlags};
 use rustwlc::types::LogType;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const GIT_VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/git-version.txt"));
 const DRIVER_MOD_PATH: &'static str = "/proc/modules";
 
 /// Callback to route wlc logs into env_logger
@@ -154,7 +155,11 @@ fn main() {
         }
     };
     if matches.opt_present("version") {
-        println!("Way Cooler {}", VERSION);
+        if !GIT_VERSION.is_empty() {
+            println!("Way Cooler {} @ {}", VERSION, GIT_VERSION);
+        } else {
+            println!("Way Cooler {}", VERSION);
+        }
         println!("Way Cooler IPC version {}", ipc::VERSION);
         return
     }


### PR DESCRIPTION
* Added logging for when a key is bound to a command
* Added logging spitting out the environment variables
* User input and init code is now exclusively logged through `info!`. Everything else should either use `trace!` or `debug!`
* Git hash now included in non-release builds