### PR TITLE
Added ActiveWorkspace IPC command

### DIFF
--- a/src/ipc/layout.rs
+++ b/src/ipc/layout.rs
@@ -160,4 +160,11 @@ dbus_interface! {
             .and(Ok(true))
             .map_err(|err| MethodErr::failed(&format!("{:?}", err)))
     }
+
+    fn ActiveWorkspace() -> name: DBusResult<String> {
+        let tree = try!(lock_tree_dbus());
+        tree.active_workspace()
+            .map(|container| container.name())
+            .map_err(|err| MethodErr::failed(&format!("{:?}", err)))
+    }
 }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -218,6 +218,15 @@ impl Tree {
         }
     }
 
+    /// Gets a reference to the container that is the active workspace
+    pub fn active_workspace(&self) -> Result<&Container, TreeError> {
+        if let Some(node_ix) = self.0.active_ix_of(ContainerType::Workspace) {
+            Ok(&self.0.tree[node_ix])
+        } else {
+            Err(TreeError::NoActiveContainer)
+        }
+    }
+
     pub fn toggle_float(&mut self) -> CommandResult {
         if let Some(uuid) = self.active_id() {
             let is_floating: Result<bool, _> = self.0.lookup(uuid)

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -364,6 +364,29 @@ impl Container {
             _ => None
         }
     }
+
+    /// Gets the name of the container.
+    ///
+    /// Container::Root: returns simply the string "Root Container"
+    /// Container::Output: The name of the output
+    /// Container::Workspace: The name of the workspace
+    /// Container::Container: Layout style (e.g horizontal)
+    /// Container::View: The name taken from `WlcView`
+    pub fn name(&self) -> String {
+        match  *self {
+            Container::Root(_)  => "Root Container".into(),
+            Container::Output { handle, .. } => {
+                handle.get_name()
+            },
+            Container::Workspace { ref name, .. } => name.clone(),
+            Container::Container { layout, .. } => {
+                format!("{:?}", layout)
+            },
+            Container::View { handle, ..} => {
+                handle.get_title()
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Allows you to see which workspace is the current one (previously impossible, unless you want to construct the tree using the unstable `Debug`, parse the (bad) json in there, and reconstruct the active path using `ActiveContainer`).

This allows bar programs to display the active workspace differently.