### PR TITLE
Added gap support

### DIFF
--- a/config/init.lua
+++ b/config/init.lua
@@ -54,9 +54,7 @@ local key = config.key -- Alias key so it's faster to type
 
 way_cooler.terminal = "weston-terminal" -- Use the terminal of your choice
 
--- The width of gaps between windows in pixels
--- Setting it to anything <= 0 puts no gaps between windows.
-way_cooler.gap_size = 0
+way_cooler.gap_size = 0 -- The width of gaps between windows in pixels
 
 local keys = {
   -- Open dmenu

--- a/config/init.lua
+++ b/config/init.lua
@@ -54,6 +54,10 @@ local key = config.key -- Alias key so it's faster to type
 
 way_cooler.terminal = "weston-terminal" -- Use the terminal of your choice
 
+-- The width of gaps between windows in pixels
+-- Setting it to anything <= 0 puts no gaps between windows.
+way_cooler.gap_size = 0
+
 local keys = {
   -- Open dmenu
   key({ mod }, "d", "launch_dmenu"),

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -648,8 +648,18 @@ impl LayoutTree {
                             }
                         }
                     }
-                    geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
-                    geometry.size.h = geometry.size.h.saturating_sub(gap / 2);
+                    match layout {
+                        Layout::Horizontal => {
+                            geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
+                            geometry.size.h = geometry.size.h.saturating_sub(gap);
+                        },
+                        Layout::Vertical => {
+                            geometry.size.w = geometry.size.w.saturating_sub(gap);
+                            geometry.size.h = geometry.size.h.saturating_sub(gap / 2);
+                        }
+                    }
+                    /*geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
+                    geometry.size.h = geometry.size.h.saturating_sub(gap / 2);*/
                     geometry
                 },
                 // Do nothing, will get in the next recursion cycle

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -221,6 +221,7 @@ impl LayoutTree {
                             self.generic_tile(node_ix, geometry, children,
                                               new_size_f, remaining_size_f, new_point_f,
                                               fullscreen_apps);
+                            self.add_gaps(node_ix);
                         }
                     }
                 }
@@ -648,7 +649,7 @@ impl LayoutTree {
                         }
                     }
                     geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
-                    geometry.size.h = geometry.size.h.saturating_sub(gap );
+                    geometry.size.h = geometry.size.h.saturating_sub(gap / 2);
                     geometry
                 },
                 // Do nothing, will get in the next recursion cycle

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -221,7 +221,8 @@ impl LayoutTree {
                             self.generic_tile(node_ix, geometry, children,
                                               new_size_f, remaining_size_f, new_point_f,
                                               fullscreen_apps);
-                            self.add_gaps(node_ix);
+                            self.add_gaps(node_ix)
+                                .expect("Couldn't add gaps to vertical container");
                         }
                     }
                 }
@@ -658,8 +659,6 @@ impl LayoutTree {
                             geometry.size.h = geometry.size.h.saturating_sub(gap / 2);
                         }
                     }
-                    /*geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
-                    geometry.size.h = geometry.size.h.saturating_sub(gap / 2);*/
                     geometry
                 },
                 // Do nothing, will get in the next recursion cycle

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -672,7 +672,6 @@ impl LayoutTree {
             }
         }
         let v: Vec<Geometry> = children.iter().map(|ix| self.tree[*ix].get_geometry().unwrap()).collect();
-        warn!("Children {:#?}", v);
         Ok(())
     }
 }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -290,9 +290,14 @@ impl LayoutTree {
         let root_ix = self.tree.root_ix();
         let root_c_ix = try!(self.tree.follow_path_until(root_ix, ContainerType::Container)
                              .map_err(|_| TreeError::NoActiveContainer));
+        let parent_ix = self.tree.parent_of(node_ix)
+            .expect("View had no parent node!");
         try!(self.tree.move_into(node_ix, root_c_ix)
              .map_err(|err| TreeError::PetGraph(err)));
         self.tree.set_ancestor_paths_active(node_ix);
+        if self.tree.can_remove_empty_parent(parent_ix) {
+            try!(self.remove_view_or_container(parent_ix));
+        }
         let parent_ix = self.tree.parent_of(root_c_ix).unwrap();
         self.layout(parent_ix);
         Ok(())

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -630,7 +630,7 @@ impl LayoutTree {
         let children = self.tree.children_of(node_ix);
         for (index, child_ix) in children.iter().enumerate() {
             let child = &mut self.tree[*child_ix];
-            let new_geo = match *child {
+            match *child {
                 Container::View { handle, ref mut prev_geometry, .. } => {
                     let mut geometry = prev_geometry
                         .clone()
@@ -659,7 +659,7 @@ impl LayoutTree {
                             geometry.size.h = geometry.size.h.saturating_sub(gap / 2);
                         }
                     }
-                    geometry
+                    handle.set_geometry(ResizeEdge::empty(), geometry);
                 },
                 // Do nothing, will get in the next recursion cycle
                 Container::Container { .. } => {continue},
@@ -669,8 +669,7 @@ impl LayoutTree {
                     error!("Found: {:#?}", container);
                     panic!("Applying gaps, found a non-view/container")
                 }
-            };
-            child.set_geometry(ResizeEdge::empty(), new_geo);
+            }
         }
         let v: Vec<Geometry> = children.iter().map(|ix| self.tree[*ix].get_geometry().unwrap()).collect();
         warn!("Children {:#?}", v);

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -671,7 +671,6 @@ impl LayoutTree {
                 }
             }
         }
-        let v: Vec<Geometry> = children.iter().map(|ix| self.tree[*ix].get_geometry().unwrap()).collect();
         Ok(())
     }
 }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -634,17 +634,11 @@ impl LayoutTree {
                         .unwrap_or_else(|| handle.get_geometry()
                                         .expect("Couldn't get geometry\
                                                  from WlcView"));
-                    if index == 0 || index == children.len() - 1 {
-                        // TODO This only works with horizontal
-                        /*geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
-                        geometry.size.h = geometry.size.h.saturating_sub(gap);
-                        geometry.origin.x += (gap / 2) as i32;
-                        geometry.origin.y += (gap / 2) as i32;*/
-                    } else {
+                    geometry.origin.x += (gap / 2) as i32;
+                    if (index == children.len() - 1) {
                         geometry.size.w = geometry.size.w.saturating_sub(gap);
-                        geometry.size.h = geometry.size.h.saturating_sub(gap);
-                        //geometry.origin.x += (gap / 2) as i32;
-                        geometry.origin.y += (gap / 2) as i32;
+                    } else {
+                        geometry.size.w = geometry.size.w.saturating_sub(gap / 2);
                     }
                     geometry
                 },

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -628,7 +628,6 @@ impl LayoutTree {
     ///
     /// If the `NodeIndex` doesn't point to a container, an error is returned.
     fn add_gaps(&mut self, node_ix: NodeIndex) -> CommandResult {
-        // TODO Fullscreen with gaps doesn't normalize properly when un-fullscreening
         let layout = match self.tree[node_ix] {
             Container::Container { layout, .. } => layout,
             _ => return Err(TreeError::UuidNotAssociatedWith(
@@ -648,12 +647,8 @@ impl LayoutTree {
         for (index, child_ix) in children.iter().enumerate() {
             let child = &mut self.tree[*child_ix];
             match *child {
-                Container::View { handle, ref mut prev_geometry, .. } => {
-                    let mut geometry = prev_geometry
-                        .clone()
-                        .unwrap_or_else(|| handle.get_geometry()
-                                        .expect("Couldn't get geometry\
-                                                 from WlcView"));
+                Container::View { handle, effective_geometry, .. } => {
+                    let mut geometry = effective_geometry;
                     geometry.origin.x += (gap / 2) as i32;
                     geometry.origin.y += (gap / 2) as i32;
                     if index == children.len() - 1 {

--- a/src/layout/actions/pointer.rs
+++ b/src/layout/actions/pointer.rs
@@ -16,7 +16,7 @@ impl LayoutTree {
     pub fn grab_at_corner(&mut self, id: Uuid, edge: ResizeEdge)
                           -> Result<Point, TreeError> {
         let container = try!(self.lookup(id));
-        let Geometry { mut origin, size } = container.get_geometry()
+        let Geometry { mut origin, size } = container.get_actual_geometry()
             .expect("Container had no geometry");
         drop(container);
         if edge.contains(RESIZE_TOPLEFT) {

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -125,7 +125,7 @@ pub fn move_active_left() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Left)
             .unwrap_or_else(|_| {
-                warn!("Could not focus right");
+                warn!("Could not focus left");
             })
     }
 }
@@ -134,7 +134,7 @@ pub fn move_active_right() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Right)
             .unwrap_or_else(|_| {
-                error!("Could not focus right");
+                warn!("Could not focus right");
             })
     }
 }
@@ -143,7 +143,7 @@ pub fn move_active_up() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Up)
             .unwrap_or_else(|_| {
-                warn!("Could not focus right");
+                warn!("Could not focus up");
             })
     }
 }
@@ -152,7 +152,7 @@ pub fn move_active_down() {
     if let Ok(mut tree) = try_lock_tree() {
         tree.move_active(None, Direction::Down)
             .unwrap_or_else(|_| {
-                warn!("Could not focus right");
+                warn!("Could not focus down");
             })
     }
 }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -88,6 +88,8 @@ pub enum Container {
         fullscreen: bool,
         /// The geometry of the container, relative to the parent container
         geometry: Geometry,
+        /// The width of the gap to put between windows
+        gap: u32,
         /// UUID associated with container, client program can use container
         id: Uuid,
     },
@@ -138,6 +140,7 @@ impl Container {
             floating: false,
             fullscreen: false,
             geometry: geometry,
+            gap: 0,
             id: Uuid::new_v4()
         }
     }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -97,10 +97,9 @@ pub enum Container {
         handle: WlcView,
         /// Whether this view is floating
         floating: bool,
-        /// The previous geometry of the view. Used for fullscreen rendering
-        /// This is a bit of a hack, but a fairly elegant one.
-        prev_geometry: Option<Geometry>,
-        /// Effective geometry
+        /// Effective geometry. This is the size of the container including
+        /// borders and gaps. It does _not_ change when an app becomes
+        /// fullscreen. E.g to get the fullscreen size use `handle.get_geometry`
         effective_geometry: Geometry,
         /// UUID associated with container, client program can use container
         id: Uuid,
@@ -151,7 +150,6 @@ impl Container {
         Container::View {
             handle: handle,
             floating: false,
-            prev_geometry: None,
             effective_geometry: geometry,
             id: Uuid::new_v4()
         }
@@ -216,8 +214,8 @@ impl Container {
                 size: size
             }),
             Container::Container { geometry, .. } => Some(geometry),
-            Container::View { effective_geometry, prev_geometry, ..} => {
-                Some(prev_geometry.unwrap_or(effective_geometry))
+            Container::View { effective_geometry, .. } => {
+                Some(effective_geometry)
             },
         }
     }
@@ -254,13 +252,8 @@ impl Container {
             Container::Container { ref mut geometry, .. } => {
                 *geometry = geo;
             },
-            Container::View { ref handle, ref mut effective_geometry,
-                              ref mut prev_geometry, .. } => {
-                if prev_geometry.is_some() {
-                    *prev_geometry = Some(geo);
-                } else {
-                    handle.set_geometry(edges, geo);
-                }
+            Container::View { ref handle, ref mut effective_geometry, .. } => {
+                handle.set_geometry(edges, geo);
                 *effective_geometry = geo;
             }
         }
@@ -318,14 +311,10 @@ impl Container {
     pub fn set_fullscreen(&mut self, val: bool) -> Result<(), ContainerType> {
         let c_type = self.get_type();
         match *self {
-            Container::View { handle, ref mut prev_geometry, .. } => {
+            Container::View { handle, effective_geometry, .. } => {
                 handle.set_state(VIEW_FULLSCREEN, val);
                 if !val {
-                    if let Some(geo) = prev_geometry.take() {
-                        handle.set_geometry(ResizeEdge::empty(), geo);
-                    }
-                } else {
-                    *prev_geometry = handle.get_geometry()
+                    handle.set_geometry(ResizeEdge::empty(), effective_geometry)
                 }
                 Ok(())
             },

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -140,7 +140,7 @@ impl Container {
             floating: false,
             fullscreen: false,
             geometry: geometry,
-            gap: 0,
+            gap: 50,
             id: Uuid::new_v4()
         }
     }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -231,6 +231,22 @@ impl Container {
         }
     }
 
+    /// Gets the actual geometry for a `WlcView`.
+    ///
+    /// Unlike `get_geometry`, this does not account for borders/gaps,
+    /// and instead is just a thin wrapper around `handle.get_geometry`.
+    ///
+    /// Most of the time you want `get_geometry`, as you should consider
+    /// the view + borders to be the "window".
+    ///
+    /// For non-view containers, this always returns `None`
+    pub fn get_actual_geometry(&self) -> Option<Geometry> {
+        match *self {
+            Container::View { handle, .. } => handle.get_geometry(),
+            _ => None
+        }
+    }
+
     /// Sets the geometry behind the container. Does nothing if container is root.
     ///
     /// For view you need to set the appropriate edges (which can be empty).

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -88,8 +88,6 @@ pub enum Container {
         fullscreen: bool,
         /// The geometry of the container, relative to the parent container
         geometry: Geometry,
-        /// The width of the gap to put between windows
-        gap: u32,
         /// UUID associated with container, client program can use container
         id: Uuid,
     },
@@ -142,7 +140,6 @@ impl Container {
             floating: false,
             fullscreen: false,
             geometry: geometry,
-            gap: 50,
             id: Uuid::new_v4()
         }
     }

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -216,14 +216,8 @@ impl Container {
                 size: size
             }),
             Container::Container { geometry, .. } => Some(geometry),
-            Container::View { ref handle, ref effective_geometry,
-                              ref prev_geometry, ..} => {
-                let actual_geo = prev_geometry.or_else(|| handle.get_geometry());
-                if actual_geo != Some(*effective_geometry) {
-                    Some(*effective_geometry)
-                } else {
-                    actual_geo
-                }
+            Container::View { effective_geometry, prev_geometry, ..} => {
+                Some(prev_geometry.unwrap_or(effective_geometry))
             },
         }
     }


### PR DESCRIPTION
* Can control gap width with `way_cooler.gap_width` (default 0)
  + Negative numbers are considered 0
* Gaps are separate from borders (which are currently unimplemented). It's possible to have both borders and gaps.

Fixes #206 