### PR TITLE
D-Bus commands now block locking the layout tree

### DIFF
--- a/src/ipc/utils.rs
+++ b/src/ipc/utils.rs
@@ -7,13 +7,13 @@ use dbus::tree::MethodErr;
 
 use super::{DBusResult};
 
-use layout::{Direction, Layout, Tree, try_lock_tree};
+use layout::{Direction, Layout, Tree, lock_tree};
 
 use rustwlc::{ResizeEdge, RESIZE_TOP, RESIZE_BOTTOM,
               RESIZE_LEFT, RESIZE_RIGHT};
 
 pub fn lock_tree_dbus() -> DBusResult<Tree> {
-    match try_lock_tree() {
+    match lock_tree() {
         Ok(tree) => Ok(tree),
         Err(err) => Err(MethodErr::failed(&format!("{:?}", err)))
     }

--- a/src/layout/commands.rs
+++ b/src/layout/commands.rs
@@ -1,6 +1,6 @@
 //! Commands from the user to manipulate the tree
 
-use super::{try_lock_tree, try_lock_action};
+use super::{try_lock_tree, lock_tree, try_lock_action};
 use super::{Action, ActionErr, Bar, Container, ContainerType,
             Direction, Handle, Layout, TreeError};
 use super::Tree;
@@ -159,7 +159,7 @@ pub fn move_active_down() {
 }
 
 pub fn tree_as_json() -> Json {
-    if let Ok(tree) = try_lock_tree() {
+    if let Ok(tree) = lock_tree() {
         tree.0.to_json()
     } else {
         Json::Null


### PR DESCRIPTION
Shaking your mouse violently should no longer make your top bar suddenly stop displaying the workspace listing ;)