### PR TITLE
Various fixes from regressions from the border feature

### DIFF
--- a/src/layout/actions/focus.rs
+++ b/src/layout/actions/focus.rs
@@ -302,17 +302,4 @@ impl LayoutTree {
             Ok(())
         }
     }
-
-
-    /// Normalizes the geometry of a view to be the same size as it's siblings,
-    /// based on the parent container's layout, at the 0 point of the parent container.
-    /// Note this does not auto-tile, only modifies this one view.
-    ///
-    /// Useful if a container's children want to be evenly distributed, or a new view
-    /// is being added.
-    pub fn normalize_view(&mut self, view: WlcView) {
-        if let Some(view_ix) = self.tree.descendant_with_handle(self.tree.root_ix(), &view) {
-            self.normalize_container(view_ix);
-        }
-    }
 }

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -1,7 +1,7 @@
 use std::cmp;
 
 use petgraph::graph::NodeIndex;
-use rustwlc::{Geometry, Point, Size, ResizeEdge};
+use rustwlc::{WlcView, Geometry, Point, Size, ResizeEdge};
 
 use super::super::{LayoutTree, TreeError};
 use super::super::commands::CommandResult;
@@ -535,10 +535,20 @@ impl LayoutTree {
         }
     }
 
+    /// Normalizes the geometry of a view to be the same size as it's siblings,
+    /// based on the parent container's layout, at the 0 point of the parent container.
+    /// Note this does not auto-tile, only modifies this one view.
+    ///
+    /// Useful if a container's children want to be evenly distributed, or a new view
+    /// is being added.
+    pub fn normalize_view(&mut self, view: WlcView) {
+        if let Some(view_ix) = self.tree.descendant_with_handle(self.tree.root_ix(), &view) {
+            self.normalize_container(view_ix);
+        }
+    }
+
     /// Normalizes the geometry of a view or a container of views so that
     /// the view is the same size as its siblings.
-    ///
-    /// See `normalize_view` for more information
     pub fn normalize_container(&mut self, node_ix: NodeIndex) {
         // if floating, do not normalize
         if self.tree[node_ix].floating() {

--- a/src/layout/actions/movement.rs
+++ b/src/layout/actions/movement.rs
@@ -244,7 +244,7 @@ impl LayoutTree {
             return Err(TreeError::Movement(MovementError::NotFloating(node_ix)))
         }
         match *container {
-            Container::View { handle, .. } => {
+            Container::View { handle, ref mut effective_geometry, .. } => {
                 let dx = point.x - old_point.x;
                 let dy = point.y - old_point.y;
                 let mut geo = handle.get_geometry()
@@ -252,14 +252,15 @@ impl LayoutTree {
                 geo.origin.x += dx;
                 geo.origin.y += dy;
                 handle.set_geometry(ResizeEdge::empty(), geo);
-                container.draw_borders();
-                Ok(())
+                effective_geometry.origin = geo.origin;
             },
             Container::Container { id, .. } | Container::Workspace { id, .. } |
             Container::Output { id, .. } | Container::Root(id) => {
-                Err(TreeError::UuidWrongType(id, vec!(ContainerType::View)))
+                return Err(TreeError::UuidWrongType(id, vec!(ContainerType::View)))
             }
         }
+        container.draw_borders();
+        Ok(())
     }
 }
 

--- a/src/layout/core/tree.rs
+++ b/src/layout/core/tree.rs
@@ -196,6 +196,7 @@ impl LayoutTree {
         if let Some(active_ix) = self.active_container {
             self.tree[active_ix].clear_border_color()
                 .expect("Could not clear border color");
+            self.tree[active_ix].draw_borders();
         }
         self.tree[node_ix].active_border_color()
             .expect("Could set active border color");
@@ -215,10 +216,7 @@ impl LayoutTree {
         if !self.tree[node_ix].floating() {
             self.tree.set_ancestor_paths_active(node_ix);
         }
-        /// Need to layout workspace to set active border correctly.
-        let workspace_ix = self.tree.ancestor_of_type(node_ix, ContainerType::Workspace)
-            .expect("View/Container did not have a workspace associated with it");
-        self.layout(workspace_ix);
+        self.tree[node_ix].draw_borders();
         Ok(())
     }
 


### PR DESCRIPTION
* Containers tile correctly again
* Floating views will no longer "jump" back to their original place once they are interacted with
* Moved `normalize_view` into `layout.rs` (which makes more sense than it being in `focus.rs`)