### PR TITLE
Fixes leading up to 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Gitter](https://badges.gitter.im/Immington-Industries/way-cooler.svg)](https://gitter.im/Immington-Industries/way-cooler?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Crates.io](https://img.shields.io/crates/v/way-cooler.svg)](https://crates.io/crates/way-cooler)
 [![Build Status](https://travis-ci.org/Immington-Industries/way-cooler.svg?branch=master)](https://travis-ci.org/Immington-Industries/way-cooler)
-[![Coverage Status](https://coveralls.io/repos/github/Immington-Industries/way-cooler/badge.svg)](https://coveralls.io/github/Immington-Industries/way-cooler)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Immington-Industries/way-cooler/)
 
 Way Cooler is a customizable tiling window manager written in [Rust][] for [Wayland][wayland].

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -634,6 +634,15 @@ impl LayoutTree {
                 Container::View { handle, .. } => {
                     handle.set_geometry(ResizeEdge::empty(), output_geometry);
                     handle.bring_to_front();
+                    let views = handle.get_output().get_views();
+                    // TODO It would be nice to not have to iterate vier
+                    // all the views just to do this.
+                    for view in views {
+                        // make sure children render above fullscreen parent
+                        if view.get_parent() == handle {
+                            view.bring_to_front();
+                        }
+                    }
                     None
                 },
                 Container::Container { ref mut geometry, .. } => {

--- a/src/layout/actions/layout.rs
+++ b/src/layout/actions/layout.rs
@@ -110,7 +110,7 @@ impl LayoutTree {
                 // place floating children above everything else
                 let root_ix = self.tree.children_of(node_ix)[0];
                 for child_ix in self.tree.floating_children(root_ix) {
-                    self.place_floating(child_ix);
+                    self.place_floating(child_ix, fullscreen_apps);
                 }
             },
             ContainerType::Container => {
@@ -343,7 +343,12 @@ impl LayoutTree {
 
     /// If the node is floating, places it at its reported position, above all
     /// other nodes.
-    fn place_floating(&mut self, node_ix: NodeIndex) {
+    fn place_floating(&mut self, node_ix: NodeIndex,
+                      fullscreen_apps: &mut Vec<NodeIndex>) {
+        if self.tree[node_ix].fullscreen() {
+            fullscreen_apps.push(node_ix);
+            return;
+        }
         if !self.tree[node_ix].floating() {
             // This could mess up the layout very badly, that's why it's an error
             error!("Tried to absolutely place a non-floating view!");
@@ -361,7 +366,7 @@ impl LayoutTree {
             container.draw_borders();
         }
         for child_ix in self.tree.floating_children(node_ix) {
-            self.place_floating(child_ix);
+            self.place_floating(child_ix, fullscreen_apps);
         }
     }
 

--- a/src/layout/core/container.rs
+++ b/src/layout/core/container.rs
@@ -350,11 +350,29 @@ impl Container {
     /// If called on a non View/Container, then returns an Err with the wrong type.
     pub fn set_fullscreen(&mut self, val: bool) -> Result<(), ContainerType> {
         let c_type = self.get_type();
+        let floating = self.floating();
         match *self {
             Container::View { handle, effective_geometry, .. } => {
                 handle.set_state(VIEW_FULLSCREEN, val);
                 if !val {
-                    handle.set_geometry(ResizeEdge::empty(), effective_geometry)
+                    let new_geometry;
+                    if floating {
+                        let output_size = handle.get_output().get_resolution()
+                            .expect("output had no resolution");
+                        new_geometry = Geometry {
+                            size: Size {
+                                h: output_size.h / 2,
+                                w: output_size.w / 2
+                            },
+                            origin: Point {
+                                x: (output_size.w / 2 - output_size.w / 4) as i32 ,
+                                y: (output_size.h / 2 - output_size.h / 4) as i32
+                            }
+                        };
+                    } else {
+                        new_geometry = effective_geometry;
+                    }
+                    handle.set_geometry(ResizeEdge::empty(), new_geometry)
                 }
                 Ok(())
             },

--- a/src/render/color.rs
+++ b/src/render/color.rs
@@ -31,10 +31,10 @@ impl Color {
 }
 
 impl From<u32> for Color {
-    fn from(mut val: u32) -> Self {
-        // Ignore first two bits, we don't care about alpha
-        val <<= 2;
-        let values = unsafe { ::std::mem::transmute::<u32, [u8; 4]>(val) };
-        Color::solid_color(values[2], values[1], values[0])
+    fn from(val: u32) -> Self {
+        let blue = ((val & 0xff0000) >> 16) as u8;
+        let green = ((val & 0x00ff00) >> 8) as u8;
+        let red = (val & 0x0000ff) as u8;
+        Color::solid_color(red, green, blue)
     }
 }

--- a/src/render/renderable.rs
+++ b/src/render/renderable.rs
@@ -3,7 +3,7 @@
 //! The buffer can only be modified by casting the type to a `Drawable`.
 
 use rustwlc::{Geometry, WlcOutput};
-use rustwlc::render::{write_pixels, wlc_pixel_format};
+use rustwlc::render::{write_pixels, wlc_pixel_format, calculate_stride};
 use cairo::{self, Context, ImageSurface, Operator};
 use super::draw::BaseDraw;
 
@@ -84,6 +84,11 @@ pub trait Renderable {
         }
         if geometry.origin.y < 0 {
             geometry.origin.y = 0;
+        }
+        let stride = calculate_stride(geometry.size.w);
+        if stride * geometry.size.h > buffer.len() as u32 {
+            warn!("Buffer to big to draw! Not drawing");
+            return
         }
         write_pixels(wlc_pixel_format::WLC_RGBA8888, geometry, &buffer);
     }


### PR DESCRIPTION
0.5 is turning out to be a short release, due to the uncertainty around wlc. These are some fixes to make 0.5 stable so that it can be released before we do the push to the new compositor.

* Fixes many crashes/segfaults that were happening from trying to get wlc to draw a buffer bigger than it can handle
* Can now fullscreen floating views and they will properly tile.
* Children views of fullscreen apps (e.g, right click context menus for terminals) will now properly render on top of the fullscreen app.
* Fixed parsing color values, we were reading them backwards and somewhat upside down. Using a mirror helps.