### PR TITLE
Implement the clients property for tag, stored in an associate value.

### DIFF
--- a/awesome/src/objects/client.rs
+++ b/awesome/src/objects/client.rs
@@ -10,7 +10,7 @@ use rlua::{self, Lua, Table, ToLua, UserData, Value};
 use common::{class::{self, Class, ClassBuilder},
              object::{Object, Objectable}};
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Hash)]
 pub struct ClientState {
     // TODO Fill in
     pub dummy: i32
@@ -27,7 +27,7 @@ impl Default for ClientState {
 
 impl<'lua> PartialEq for Client<'lua> {
     fn eq(&self, other: &Self) -> bool {
-        *self.state().unwrap() == *other.state().unwrap()
+        &*self.state().unwrap() as *const _ == &*other.state().unwrap() as *const _
     }
 }
 


### PR DESCRIPTION
Implement the public API for the client property, except for the signals.
To avoid the Rust-side cloning, values are stored as-is in an associate table (`__clients`) on the object.
This allows the clients to be shared amongst tags as the same Lua-side tables.
A bottleneck occurs when setting the new clients, as one needs to iterate over the old and new client lists to check for common values. This should not be a performance problem though, as it is not used frequently.